### PR TITLE
Improve get_dask_client() and its unit tests

### DIFF
--- a/cluster_configs/salish_cluster.yaml
+++ b/cluster_configs/salish_cluster.yaml
@@ -1,4 +1,4 @@
-# Configuration file for a dask cluster on salish
+# Configuration for a dask cluster on salish
 
 name: salish dask cluster
 processes: True

--- a/cluster_configs/unit_test_cluster.yaml
+++ b/cluster_configs/unit_test_cluster.yaml
@@ -1,0 +1,7 @@
+# Configuration for a dask cluster used by unit tests suite
+# ** DO NOT USE FOR PROCESSING **
+
+name: unit test dask cluster
+processes: True
+number of workers: 1
+threads per worker: 1

--- a/docs/subcommands/extract.rst
+++ b/docs/subcommands/extract.rst
@@ -45,7 +45,7 @@ Dask Cluster Configuration File
 
 Example:
 
-.. literalinclude:: salish_cluster.yaml
+.. literalinclude:: ../../cluster_configs/salish_cluster.yaml
    :language: yaml
 
 

--- a/docs/subcommands/extract_example.yaml
+++ b/docs/subcommands/extract_example.yaml
@@ -2,7 +2,7 @@
 
 model profile: SalishSeaCast-201812.yaml
 
-dask cluster: docs/subcommands/salish_cluster.yaml
+dask cluster: salish_cluster.yaml
 
 start date: 2007-01-01
 end date: 2007-01-10

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -123,7 +123,7 @@ def _load_model_profile(model_profile_yaml):
 ## Functions below will probably eventually  be refactored into separate module(s)
 
 
-def get_dask_client(dask_config):
+def get_dask_client(dask_config_yaml):
     """Return a dask cluster client.
 
     If :kbd:`dask_cluster` is a dask cluster configuration YAML file,
@@ -134,28 +134,28 @@ def get_dask_client(dask_config):
     in the form :kbd:`host_ip:port`,
     and a client connected to that cluster is returned.
 
-    :param dask_config: File path and name of the YAML file to read the dask cluster configuration
-                        dictionary from,
-                        or a :kbd:`host_ip:port` string of an existing dask cluster fot connect to.
-                        Please see :ref:`ReshaprDaskClusterYAMLFile` for details.
-    :type dask_config: :py:class:`pathlib.Path` or str
+    :param dask_config_yaml: File path and name of the YAML file to read the dask cluster configuration
+                             dictionary from,
+                             or a :kbd:`host_ip:port` string of an existing dask cluster fot connect to.
+                             Please see :ref:`ReshaprDaskClusterYAMLFile` for details.
+    :type dask_config_yaml: :py:class:`pathlib.Path` or str
 
     :return: Dask cluster client.
     :rtype: :py:class:`dask.distributed.Client`
 
     :raises: :py:exc:`SystemExit` if a client cannot be created.
     """
-    log = logger.bind(dask_config=dask_config)
+    log = logger.bind(dask_config_yaml=dask_config_yaml)
     try:
         # Assume config is a YAML file path
-        with Path(dask_config).open("rt") as f:
+        with Path(dask_config_yaml).open("rt") as f:
             cluster_config = yaml.safe_load(f)
         log.debug("loaded dask cluster config")
     except FileNotFoundError:
         # Maybe config is a host_ip:port string
         try:
             # Connect to an existing cluster
-            client = dask.distributed.Client(dask_config)
+            client = dask.distributed.Client(dask_config_yaml)
             log = log.bind(dashboard_link=client.dashboard_link)
             log.info("dask cluster dashboard")
             return client

--- a/tests/core/test_dask_cluster.py
+++ b/tests/core/test_dask_cluster.py
@@ -29,21 +29,27 @@ from reshapr.core.extract import get_dask_client
 class TestGetDaskClient:
     """Unit tests for get_dask_client() function."""
 
-    @pytest.mark.parametrize(
-        "dask_config",
-        (
-            "nonexistent.yaml",
-            "localhost",
-            "127.0.0.1",
-        ),
-    )
-    def test_bad_config(self, dask_config, log_output):
+    def test_no_cluster_config_from_path(self, log_output):
+        dask_config_yaml = "nonexistent.yaml"
         with pytest.raises(SystemExit) as exc_info:
-            get_dask_client(dask_config)
+            get_dask_client(dask_config_yaml)
 
         assert exc_info.value.code == 1
         assert log_output.entries[0]["log_level"] == "error"
-        assert log_output.entries[0]["dask_config"] == dask_config
+        assert log_output.entries[0]["dask_config"] == dask_config_yaml
+        assert (
+            log_output.entries[0]["event"]
+            == "unrecognized dask cluster config; expected YAML file path or host_ip:port"
+        )
+
+    def test_bad_host_port_spec(self, log_output):
+        dask_config_yaml = "127.0.0.1"
+        with pytest.raises(SystemExit) as exc_info:
+            get_dask_client(dask_config_yaml)
+
+        assert exc_info.value.code == 1
+        assert log_output.entries[0]["log_level"] == "error"
+        assert log_output.entries[0]["dask_config"] == dask_config_yaml
         assert (
             log_output.entries[0]["event"]
             == "unrecognized dask cluster config; expected YAML file path or host_ip:port"

--- a/tests/core/test_dask_cluster.py
+++ b/tests/core/test_dask_cluster.py
@@ -36,7 +36,7 @@ class TestGetDaskClient:
 
         assert exc_info.value.code == 1
         assert log_output.entries[0]["log_level"] == "error"
-        assert log_output.entries[0]["dask_config"] == dask_config_yaml
+        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
         assert (
             log_output.entries[0]["event"]
             == "unrecognized dask cluster config; expected YAML file path or host_ip:port"
@@ -49,32 +49,32 @@ class TestGetDaskClient:
 
         assert exc_info.value.code == 1
         assert log_output.entries[0]["log_level"] == "error"
-        assert log_output.entries[0]["dask_config"] == dask_config_yaml
+        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
         assert (
             log_output.entries[0]["event"]
             == "unrecognized dask cluster config; expected YAML file path or host_ip:port"
         )
 
     @pytest.mark.parametrize(
-        "dask_config",
+        "dask_config_yaml",
         (
             "localhost:4343",
             "127.0.0.1:4343",
         ),
     )
-    def test_no_cluster(self, dask_config, log_output, monkeypatch):
+    def test_no_cluster(self, dask_config_yaml, log_output, monkeypatch):
         class MockClient:
-            def __init__(self, dask_config):
+            def __init__(self, dask_config_yaml):
                 raise OSError
 
         monkeypatch.setattr(dask.distributed, "Client", MockClient)
 
         with pytest.raises(SystemExit) as exc_info:
-            get_dask_client(dask_config)
+            get_dask_client(dask_config_yaml)
 
         assert exc_info.value.code == 1
         assert log_output.entries[0]["log_level"] == "error"
-        assert log_output.entries[0]["dask_config"] == dask_config
+        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
         assert (
             log_output.entries[0]["event"]
             == "requested dask cluster is not running or refused your connection"
@@ -87,20 +87,20 @@ class TestGetDaskClient:
             threads_per_worker=1,
             processes=True,
         )
-        dask_config = cluster.scheduler_address
+        dask_config_yaml = cluster.scheduler_address
 
-        client = get_dask_client(dask_config)
+        client = get_dask_client(dask_config_yaml)
         dashboard_link = client.dashboard_link
         client.close()
 
         assert log_output.entries[0]["log_level"] == "info"
-        assert log_output.entries[0]["dask_config"] == dask_config
+        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
         assert log_output.entries[0]["dashboard_link"] == dashboard_link
         assert log_output.entries[0]["event"] == "dask cluster dashboard"
 
     def test_launch_cluster(self, log_output, tmp_path):
-        dask_config = tmp_path / "test_cluster.yaml"
-        dask_config.write_text(
+        dask_config_yaml = tmp_path / "test_cluster.yaml"
+        dask_config_yaml.write_text(
             textwrap.dedent(
                 """\
                 name: test dask cluster
@@ -111,15 +111,15 @@ class TestGetDaskClient:
             )
         )
 
-        client = get_dask_client(dask_config)
+        client = get_dask_client(dask_config_yaml)
         dashboard_link = client.dashboard_link
         client.close()
 
         assert log_output.entries[0]["log_level"] == "debug"
-        assert log_output.entries[0]["dask_config"] == dask_config
+        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
         assert log_output.entries[0]["event"] == "loaded dask cluster config"
 
         assert log_output.entries[1]["log_level"] == "info"
-        assert log_output.entries[1]["dask_config"] == dask_config
+        assert log_output.entries[1]["dask_config_yaml"] == dask_config_yaml
         assert log_output.entries[1]["dashboard_link"] == dashboard_link
         assert log_output.entries[1]["event"] == "dask cluster dashboard"

--- a/tests/core/test_dask_cluster.py
+++ b/tests/core/test_dask_cluster.py
@@ -17,7 +17,9 @@
 
 """Unit test for get_dask_client() function.
 """
+import os
 import textwrap
+from pathlib import Path
 
 import dask.distributed
 import pytest
@@ -29,18 +31,60 @@ from reshapr.core.extract import get_dask_client
 class TestGetDaskClient:
     """Unit tests for get_dask_client() function."""
 
-    def test_no_cluster_config_from_path(self, log_output):
-        dask_config_yaml = "nonexistent.yaml"
+    def test_load_cluster_config_from_path(self, log_output, tmp_path):
+        dask_config_yaml = tmp_path / "test_cluster.yaml"
+        dask_config_yaml.write_text(
+            textwrap.dedent(
+                """\
+                name: test dask cluster
+                processes: True
+                number of workers: 1
+                threads per worker: 1
+                """
+            )
+        )
+
+        client = get_dask_client(dask_config_yaml)
+        client.close()
+
+        assert log_output.entries[0]["log_level"] == "debug"
+        assert log_output.entries[0]["dask_config_yaml"] == os.fspath(dask_config_yaml)
+        assert log_output.entries[0]["event"] == "loaded dask cluster config"
+
+    def test_load_cluster_config_from_cluster_configs_dir(self, log_output):
+        dask_config_yaml = Path("unit_test_cluster.yaml")
+
+        client = get_dask_client(dask_config_yaml)
+        client.close()
+
+        assert log_output.entries[0]["log_level"] == "debug"
+        cluster_configs_path = Path(__file__).parent.parent.parent / "cluster_configs"
+        assert log_output.entries[0]["dask_config_yaml"] == os.fspath(
+            cluster_configs_path / dask_config_yaml
+        )
+        assert log_output.entries[0]["event"] == "loaded dask cluster config"
+
+    def test_no_cluster_config_from_path(self, log_output, tmp_path):
+        dask_config_yaml = tmp_path / "nonexistent.yaml"
         with pytest.raises(SystemExit) as exc_info:
             get_dask_client(dask_config_yaml)
 
         assert exc_info.value.code == 1
         assert log_output.entries[0]["log_level"] == "error"
-        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
-        assert (
-            log_output.entries[0]["event"]
-            == "unrecognized dask cluster config; expected YAML file path or host_ip:port"
+        assert log_output.entries[0]["dask_config_yaml"] == os.fspath(dask_config_yaml)
+        assert log_output.entries[0]["event"] == "dask cluster config file not found"
+
+    def test_no_cluster_config_in_cluster_configs_dir(self, log_output, tmp_path):
+        nonexistent_dask_config_yaml = Path("nonexistent.yaml")
+        with pytest.raises(SystemExit) as exc_info:
+            get_dask_client(nonexistent_dask_config_yaml)
+
+        assert exc_info.value.code == 1
+        assert log_output.entries[0]["log_level"] == "error"
+        assert log_output.entries[0]["dask_config_yaml"] == os.fspath(
+            nonexistent_dask_config_yaml
         )
+        assert log_output.entries[0]["event"] == "dask cluster config file not found"
 
     def test_bad_host_port_spec(self, log_output):
         dask_config_yaml = "127.0.0.1"
@@ -99,27 +143,16 @@ class TestGetDaskClient:
         assert log_output.entries[0]["event"] == "dask cluster dashboard"
 
     def test_launch_cluster(self, log_output, tmp_path):
-        dask_config_yaml = tmp_path / "test_cluster.yaml"
-        dask_config_yaml.write_text(
-            textwrap.dedent(
-                """\
-                name: test dask cluster
-                processes: True
-                number of workers: 1
-                threads per worker: 1
-                """
-            )
-        )
+        dask_config_yaml = Path("unit_test_cluster.yaml")
 
         client = get_dask_client(dask_config_yaml)
         dashboard_link = client.dashboard_link
         client.close()
 
-        assert log_output.entries[0]["log_level"] == "debug"
-        assert log_output.entries[0]["dask_config_yaml"] == dask_config_yaml
-        assert log_output.entries[0]["event"] == "loaded dask cluster config"
-
         assert log_output.entries[1]["log_level"] == "info"
-        assert log_output.entries[1]["dask_config_yaml"] == dask_config_yaml
+        cluster_configs_path = Path(__file__).parent.parent.parent / "cluster_configs"
+        assert log_output.entries[0]["dask_config_yaml"] == os.fspath(
+            cluster_configs_path / dask_config_yaml
+        )
         assert log_output.entries[1]["dashboard_link"] == dashboard_link
         assert log_output.entries[1]["event"] == "dask cluster dashboard"

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -91,7 +91,12 @@ class TestLoadModelProfile:
         )
         assert log_output.entries[0]["event"] == "loaded model profile"
 
-    def test_load_model_profile_from_model_profiles_dir(self, log_output):
+    def test_load_model_profile_from_model_profiles_dir(self, log_output, monkeypatch):
+        def mock_exists(path):
+            return True
+
+        monkeypatch.setattr(Path, "exists", mock_exists)
+
         model_profile_yaml = Path("SalishSeaCast-201812.yaml")
 
         model_profile = extract._load_model_profile(model_profile_yaml)


### PR DESCRIPTION
Fix some test suite issues, including a annoying one whereby test parametrization caused intermittent
failures due to random test order interacting badly with test that briefly launch dask clusters.

Adopt pattern from model profile loader of trying to load cluster config from a user-supplied path,
then falling back to trying to load from `Reshapr/cluster_configs/` directory. That allows pre-configured
clusters to be included in processing YAML files without paths.