### PR TITLE
Add prep and writing of netCDF file

### DIFF
--- a/docs/subcommands/extract_example.yaml
+++ b/docs/subcommands/extract_example.yaml
@@ -20,3 +20,5 @@ extracted dataset:
   name: SalishSeaCast_day_avg_diatoms
   description: Day-averaged diatoms biomass and nitrate extracted from SalishSeaCast v201812 hindcast
   deflate: True
+  format: NETCDF4
+  dest dir: /ocean/dlatorne/Atlantis/day-avg-diatoms/


### PR DESCRIPTION
Separated into 2 functions to make unit test of prep part possible.
We don't want to write large netCDF files during unit testing.