### PR TITLE
Make unused variables list global for model profiles

### DIFF
--- a/model_profiles/SalishSeaCast-201812.yaml
+++ b/model_profiles/SalishSeaCast-201812.yaml
@@ -77,8 +77,3 @@ results archive:
       w velocity:
         file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
         depth coord: depthw
-
-useless variables:
-  - time_centered
-  - nav_lon
-  - nav_lat

--- a/model_profiles/unused-variables.yaml
+++ b/model_profiles/unused-variables.yaml
@@ -1,0 +1,18 @@
+# List of dataset variables that are always dropped because they have no purpose
+# in Reshapr operations.
+# Dropping them when datasets are opened reduces the memory size of the dask tasks.
+#
+# Note that the `drop_variables` arg of xarray.open_mfdataset() is robust so that
+# variables included in this list that do not appear in a dataset do not cause problems.
+
+
+# NEMO generated variable that contains the same information as `time_counter`
+- time_centered
+
+# NEMO generated longitude and latitude fields that contain -1 values for land
+# processor grid points when land processor elimination is used.
+# If you want lon/lat fields in your dataset, use `include lons lats: True` in your
+# processing configuration YAML file to get the fields from the source given by
+# the dataset's `geo ref dataset` key.
+- nav_lon
+- nav_lat

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -23,7 +23,10 @@ import pytest
 import yaml
 
 MODEL_PROFILES_DIR = Path(__file__).parent.parent / "model_profiles"
-MODEL_PROFILES = (Path("SalishSeaCast-201812.yaml"),)
+MODEL_PROFILES = (
+    Path("SalishSeaCast-201812.yaml"),
+    Path("unused-variables.yaml"),
+)
 
 
 class TestModelProfiles:
@@ -35,6 +38,9 @@ class TestModelProfiles:
 
     @pytest.mark.parametrize("model_profile_yaml", MODEL_PROFILES)
     def test_required_items(self, model_profile_yaml):
+        if model_profile_yaml == Path("unused-variables.yaml"):
+            # unused-variables.yaml isn't a model profile, it just lives with them
+            return
         with (MODEL_PROFILES_DIR / model_profile_yaml).open("rt") as f:
             model_profile = yaml.safe_load(f)
 
@@ -44,6 +50,17 @@ class TestModelProfiles:
         assert model_profile["results archive"]["datasets"] is not None
         assert model_profile["time coord"] is not None
         assert model_profile["chunk size"] is not None
+
+    def test_unused_variables(self):
+        with (MODEL_PROFILES_DIR / "unused-variables.yaml").open("rt") as f:
+            unused_vars = yaml.safe_load(f)
+
+        expected = [
+            "time_centered",
+            "nav_lon",
+            "nav_lat",
+        ]
+        assert unused_vars == expected
 
 
 class TestSalishSeaCast201812:
@@ -66,11 +83,6 @@ class TestSalishSeaCast201812:
             "x": 398,
         }
         assert model_profile["chunk size"] == expected_chunk_size
-        assert model_profile["useless variables"] == [
-            "time_centered",
-            "nav_lon",
-            "nav_lat",
-        ]
 
     @pytest.mark.parametrize(
         "var_group, file_pattern, depth_coord",


### PR DESCRIPTION
Takes advantage of the `drop_variables` arg of `xarray.open_mfdataset()` being robust so that
variables included in this list that do not appear in a dataset do not cause problems.

Doing this moves maintenance of the list of unused variables to 1 file instead of having to maintain it
on a profile by profile basis.
It also lays foundation for a potential dataset variable group discovery feature.