### PR TITLE
Add HRDPS model profiles

### DIFF
--- a/model_profiles/HRDPS-2.5km-GEMLAM-22sep11onward.yaml
+++ b/model_profiles/HRDPS-2.5km-GEMLAM-22sep11onward.yaml
@@ -1,0 +1,49 @@
+# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
+# 2.5 km resolution GEMLAM pre-operational model product fields processed for use as
+# surface forcing fields for the SalishSeaCast models.
+#
+# This model profile is for the SalishSeaCast NEMO forcing files generated
+# from the HRDPS model pre-operational period 2011-09-22 to 2014-11-18 product fields
+# provided from archives maintained by the ECCC Vancouver office.
+#
+# For the HRDPS model product fields from the 2007-01-03 to 2011-09-21 pre-operational
+# period please use the HRDPS-2.5km-GEMLAM-pre22sep11.yaml profile.
+#
+# For the HRDPS operational model product fields downloaded from the ECCC Datamart servers
+# daily from 2014-09-12 to present please use the HRDPS-2.5km-operational.yaml profile.
+
+name: HRDPS-2.5km-GEMLAM-22sep11onward
+
+time coord:
+  name: time_counter
+y coord:
+  name: y
+x coord:
+  name: x
+
+# Chunking scheme used for the netCDF4 files
+# Note that coordinate names (keys) are conceptual here.
+# They are replaced with actual coordinate names in files in the code;
+# e.g. time is replaced by time_counter for dataset loading
+chunk size:
+  time: 24
+  y: 266
+  x: 256
+
+geo ref dataset:
+  path: /results/forcing/atmospheric/GEM2.5/gemlam/gemlam_y2011m09d22.nc
+  y coord: y
+  longitude var: nav_lon
+  x coord: x
+  latitude var: nav_lat
+
+extraction time origin: 2007-01-01
+
+results archive:
+  path: /results/forcing/atmospheric/GEM2.5/gemlam/
+  datasets:
+    hour:
+      surface fields:
+        # Note: the pattern here is for the NEMO forcing file naming convention;
+        # e.g. gemlam_y2015m09d22.nc
+        file pattern: gemlam_{nemo_yyyymmdd}.nc

--- a/model_profiles/HRDPS-2.5km-GEMLAM-pre22sep11.yaml
+++ b/model_profiles/HRDPS-2.5km-GEMLAM-pre22sep11.yaml
@@ -1,0 +1,49 @@
+# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
+# 2.5 km resolution GEMLAM pre-operational model product fields processed for use as
+# surface forcing fields for the SalishSeaCast models.
+#
+# This model profile is for the SalishSeaCast NEMO forcing files generated
+# from the HRDPS model pre-operational period 2007-01-03 to 2011-09-21 product fields
+# provided from archives maintained by the ECCC Vancouver office.
+#
+# For the HRDPS model product fields from the 2011-09-22 to 2014-11-18 pre-operational
+# period please use the HRDPS-2.5km-GEMLAM-22sep11onward.yaml profile.
+#
+# For the HRDPS operational model product fields downloaded from the ECCC Datamart servers
+# daily from 2014-09-12 to present please use the HRDPS-2.5km-operational.yaml profile.
+
+name: HRDPS-2.5km-GEMLAM-pre22sep11
+
+time coord:
+  name: time_counter
+y coord:
+  name: y
+x coord:
+  name: x
+
+# Chunking scheme used for the netCDF4 files
+# Note that coordinate names (keys) are conceptual here.
+# They are replaced with actual coordinate names in files in the code;
+# e.g. time is replaced by time_counter for dataset loading
+chunk size:
+  time: 24
+  y: 266
+  x: 256
+
+geo ref dataset:
+  path: /results/forcing/atmospheric/GEM2.5/gemlam/gemlam_y2007m01d03.nc
+  y coord: y
+  longitude var: nav_lon
+  x coord: x
+  latitude var: nav_lat
+
+extraction time origin: 2007-01-01
+
+results archive:
+  path: /results/forcing/atmospheric/GEM2.5/gemlam/
+  datasets:
+    hour:
+      surface fields:
+        # Note: the pattern here is for the NEMO forcing file naming convention;
+        # e.g. gemlam_y2022m02d24.nc
+        file pattern: gemlam_{nemo_yyyymmdd}.nc

--- a/model_profiles/HRDPS-2.5km-operational.yaml
+++ b/model_profiles/HRDPS-2.5km-operational.yaml
@@ -1,0 +1,48 @@
+# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
+# 2.5 km resolution operational model product fields processed for use as
+# surface forcing fields for the SalishSeaCast models
+#
+# This model profile is for the SalishSeaCast NEMO forcing files generated
+# from the HRDPS model product fields downloaded from the ECCC Datamart servers
+# daily from 2014-09-12 to present.
+# For the HRDPS model product fields from the pre-operational periods please use:
+#   2007-01-03 to 2011-09-21: the HRDPS-2.5km-GEMLAM-pre22sep11.yaml profile
+#   2011-09-22 to 2014-11-18: the HRDPS-2.5km-GEMLAM-22sep11onward.yaml profile
+
+name: HRDPS-2.5km-operational
+
+time coord:
+  name: time_counter
+y coord:
+  name: y
+  units: metres
+  comment: gridY values are distance in metres in the model y-direction from the south-west corner of the grid
+x coord:
+  name: x
+  units: metres
+  comment: gridX values are distance in metres in the model x-direction from the south-west corner of the grid
+
+# Chunking scheme used for the netCDF4 files
+# Note that coordinate names (keys) are conceptual here.
+# They are replaced with actual coordinate names in files in the code;
+# e.g. time is replaced by time_counter for dataset loading
+chunk size:
+  time: 24
+  y: 266
+  x: 256
+
+geo ref dataset:
+  path: https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaAtmosphereGridV1
+  y coord: gridY
+  x coord: gridX
+
+extraction time origin: 2007-01-01
+
+results archive:
+  path: /results/forcing/atmospheric/GEM2.5/operational/
+  datasets:
+    hour:
+      surface fields:
+        # Note: the pattern here is for the NEMO forcing file naming convention;
+        # e.g. ops_y2022m02d24.nc
+        file pattern: ops_{nemo_yyyymmdd}.nc

--- a/model_profiles/SalishSeaCast-201812.yaml
+++ b/model_profiles/SalishSeaCast-201812.yaml
@@ -2,9 +2,12 @@
 
 name: SalishSeaCast.201812
 
-time coord: time_counter
-y coord: y
-x coord: x
+time coord:
+  name: time_counter
+y coord:
+  name: y
+x coord:
+  name: x
 
 # Chunking scheme used for the netCDF4 files
 # Note that coordinate names (keys) are conceptual here.

--- a/model_profiles/SalishSeaCast-201812.yaml
+++ b/model_profiles/SalishSeaCast-201812.yaml
@@ -6,9 +6,9 @@ time coord: time_counter
 y coord: y
 x coord: x
 
-# Chunking scheme used in the netCDF4 files
+# Chunking scheme used for the netCDF4 files
 # Note that coordinate names (keys) are conceptual here.
-# They are replaces with actual coordinate names in files in the code;
+# They are replaced with actual coordinate names in files in the code;
 # e.g. time is replaced by time_counter for dataset loading
 chunk size:
   time: 1
@@ -28,57 +28,57 @@ results archive:
   datasets:
     day:
       auxiliary:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
         depth coord: deptht
       biology:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
         depth coord: deptht
       chemistry:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
         depth coord: deptht
       grazing and mortality:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_dia2_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_dia2_T.nc"
         depth coord: deptht
       physics tracers:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
         depth coord: deptht
       u velocity:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_U.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_U.nc"
         depth coord: depthu
       v velocity:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_V.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_V.nc"
         depth coord: depthv
       vertical turbulence:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
         depth coord: depthw
       w velocity:
-        file pattern: "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
         depth coord: depthw
     hour:
       auxiliary:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
         depth coord: deptht
       biology:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
         depth coord: deptht
       chemistry:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc"
         depth coord: deptht
       physics tracers:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
         depth coord: deptht
       primary production:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_prod_T.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_prod_T.nc"
         depth coord: deptht
       u velocity:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_U.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_U.nc"
         depth coord: depthu
       v velocity:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_V.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_V.nc"
         depth coord: depthv
       vertical turbulence:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
         depth coord: depthw
       w velocity:
-        file pattern: "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
+        file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc"
         depth coord: depthw

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -390,7 +390,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     }
     time_interval = config.get("selection", {}).get("time interval", 1)
     # stop=None in slice() means the length of the array without having to know what that is
-    time_selector = {model_profile["time coord"]: slice(0, None, time_interval)}
+    time_selector = {model_profile["time coord"]["name"]: slice(0, None, time_interval)}
     extract_time_origin = model_profile["extraction time origin"]
     match config["dataset"]["time base"]:
         case "day":
@@ -401,7 +401,7 @@ def calc_output_coords(source_dataset, config, model_profile):
             time_offset = "00:30:00"
     times = create_dataarray(
         "time",
-        source_dataset[model_profile["time coord"]].isel(time_selector),
+        source_dataset[model_profile["time coord"]["name"]].isel(time_selector),
         attrs={
             "standard_name": "time",
             "long_name": "Time Axis",
@@ -463,7 +463,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     y_max = config.get("selection", {}).get("grid y", {}).get("y max", None)
     y_interval = config.get("selection", {}).get("grid y", {}).get("y interval", 1)
     y_selector = slice(y_min, y_max, y_interval)
-    y_coord = model_profile["y coord"]
+    y_coord = model_profile["y coord"]["name"]
     y_indices = create_dataarray(
         "gridY",
         source_dataset[y_coord].isel({y_coord: y_selector}).astype(int),
@@ -480,7 +480,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     x_max = config.get("selection", {}).get("grid x", {}).get("x max", None)
     x_interval = config.get("selection", {}).get("grid x", {}).get("x interval", 1)
     x_selector = slice(x_min, x_max, x_interval)
-    x_coord = model_profile["x coord"]
+    x_coord = model_profile["x coord"]["name"]
     x_indices = create_dataarray(
         "gridX",
         source_dataset[x_coord].isel({x_coord: x_selector}).astype(int),

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -421,6 +421,8 @@ def calc_output_coords(source_dataset, config, model_profile):
             },
         )
         logger.debug("extraction depth coordinate", depth=depths)
+    else:
+        depths = None
 
     y_min = config.get("selection", {}).get("grid y", {}).get("y min", 0)
     y_max = config.get("selection", {}).get("grid y", {}).get("y max", None)

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -466,7 +466,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     y_coord = model_profile["y coord"]
     y_indices = create_dataarray(
         "gridY",
-        source_dataset[y_coord].isel({y_coord: y_selector}),
+        source_dataset[y_coord].isel({y_coord: y_selector}).astype(int),
         attrs={
             "standard_name": "y",
             "long_name": "Grid Y",
@@ -483,7 +483,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     x_coord = model_profile["x coord"]
     x_indices = create_dataarray(
         "gridX",
-        source_dataset[x_coord].isel({x_coord: x_selector}),
+        source_dataset[x_coord].isel({x_coord: x_selector}).astype(int),
         attrs={
             "standard_name": "x",
             "long_name": "Grid X",

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -228,7 +228,7 @@ def calc_ds_chunk_size(config, model_profile):
     """
     abstract_chunk_size = model_profile["chunk size"]
     time_chunk_size = abstract_chunk_size.pop("time")
-    chunk_size = {model_profile["time coord"]: time_chunk_size}
+    chunk_size = {model_profile["time coord"]["name"]: time_chunk_size}
     if "depth" in abstract_chunk_size:
         depth_chunk_size = abstract_chunk_size.pop("depth")
         time_base = config["dataset"]["time base"]
@@ -548,16 +548,16 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
     x_selector = slice(x_min, x_max, x_interval)
     if include_depth_coord:
         selector = {
-            model_profile["time coord"]: time_selector,
+            model_profile["time coord"]["name"]: time_selector,
             depth_coord: depth_selector,
-            model_profile["y coord"]: y_selector,
-            model_profile["x coord"]: x_selector,
+            model_profile["y coord"]["name"]: y_selector,
+            model_profile["x coord"]["name"]: x_selector,
         }
     else:
         selector = {
-            model_profile["time coord"]: time_selector,
-            model_profile["y coord"]: y_selector,
-            model_profile["x coord"]: x_selector,
+            model_profile["time coord"]["name"]: time_selector,
+            model_profile["y coord"]["name"]: y_selector,
+            model_profile["x coord"]["name"]: x_selector,
         }
     extracted_vars = []
     for name, var in source_dataset.data_vars.items():

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -157,10 +157,18 @@ def calc_ds_paths(config, model_profile):
         ds_path = results_archive_path
         for part in nc_files_pattern.parents[:-1]:
             ds_path = ds_path.joinpath(
-                os.fspath(part).format(ddmmmyy=ddmmmyy(day), yyyymmdd=yyyymmdd(day))
+                os.fspath(part).format(
+                    ddmmmyy=ddmmmyy(day),
+                    yyyymmdd=yyyymmdd(day),
+                    nemo_yyyymmdd=nemo_yyyymmdd(day),
+                )
             )
         ds_path = ds_path.joinpath(
-            nc_files_pattern.name.format(ddmmmyy=ddmmmyy(day), yyyymmdd=yyyymmdd(day))
+            nc_files_pattern.name.format(
+                ddmmmyy=ddmmmyy(day),
+                yyyymmdd=yyyymmdd(day),
+                nemo_yyyymmdd=nemo_yyyymmdd(day),
+            )
         )
         ds_paths.append(ds_path)
     log = log.bind(n_datasets=len(ds_paths))
@@ -190,6 +198,19 @@ def yyyymmdd(arrow_date):
     :rtype: str
     """
     return arrow_date.format("YYYYMMDD").lower()
+
+
+def nemo_yyyymmdd(arrow_date):
+    """Return an Arrow date as a string formatted using the NEMO forcing date convention;
+    i.e. y2022m02d28.
+
+    :param arrow_date: Date/time to format.
+    :type arrow_date: :py:class:`arrow.arrow.Arrow`
+
+    :return: Date formatted as NEMO forcing date.
+    :rtype: str
+    """
+    return arrow_date.format("[y]YYYY[m]MM[d]DD")
 
 
 def calc_ds_chunk_size(config, model_profile):

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -470,8 +470,10 @@ def calc_output_coords(source_dataset, config, model_profile):
         attrs={
             "standard_name": "y",
             "long_name": "Grid Y",
-            "units": "count",
-            "comment": "gridY values are grid indices in the model y-direction",
+            "units": model_profile["y coord"].get("units", "count"),
+            "comment": model_profile["y coord"].get(
+                "comment", "gridY values are grid indices in the model y-direction"
+            ),
         },
     )
     logger.debug("extraction y coordinate", y_index=y_indices)
@@ -487,8 +489,10 @@ def calc_output_coords(source_dataset, config, model_profile):
         attrs={
             "standard_name": "x",
             "long_name": "Grid X",
-            "units": "count",
-            "comment": "gridX values are grid indices in the model x-direction",
+            "units": model_profile["x coord"].get("units", "count"),
+            "comment": model_profile["x coord"].get(
+                "comment", "gridX values are grid indices in the model x-direction"
+            ),
         },
     )
     logger.debug("extraction x coordinate", x_index=x_indices)

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -226,7 +226,7 @@ def calc_ds_chunk_size(config, model_profile):
     :return: Chunks size dict to use for loading model datasets.
     :rtype: dict
     """
-    abstract_chunk_size = model_profile["chunk size"]
+    abstract_chunk_size = model_profile["chunk size"].copy()
     time_chunk_size = abstract_chunk_size.pop("time")
     chunk_size = {model_profile["time coord"]["name"]: time_chunk_size}
     if "depth" in abstract_chunk_size:

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -575,11 +575,16 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
                 if c_name != "depth"
             }
         )
+        try:
+            std_name = var.attrs["standard_name"]
+        except KeyError:
+            # HRDPS lacks standard_name for many vars, but has short_name
+            std_name = var.attrs["short_name"]
         extracted_var = create_dataarray(
             name,
             var.isel(var_selector),
             attrs={
-                "standard_name": var.attrs["standard_name"],
+                "standard_name": std_name,
                 "long_name": var.attrs["long_name"],
                 "units": var.attrs["units"],
             },

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -602,14 +602,16 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
     # Add longitude and latitude variables from geo ref dataset
     with xarray.open_dataset(model_profile["geo ref dataset"]["path"]) as grid_ds:
         y_coord = model_profile["geo ref dataset"]["y coord"]
+        lon_var = model_profile["geo ref dataset"].get("longitude var", "longitude")
         x_coord = model_profile["geo ref dataset"]["x coord"]
+        lat_var = model_profile["geo ref dataset"].get("latitude var", "latitude")
         selector = {
             y_coord: y_selector,
             x_coord: x_selector,
         }
         lons = create_dataarray(
             "longitude",
-            grid_ds.longitude.isel(selector),
+            grid_ds[lon_var].isel(selector),
             attrs={
                 "standard_name": "longitude",
                 "long_name": "Longitude",
@@ -625,7 +627,7 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
 
         lats = create_dataarray(
             "latitude",
-            grid_ds.latitude.isel(selector),
+            grid_ds[lat_var].isel(selector),
             attrs={
                 "standard_name": "latitude",
                 "long_name": "Latitude",

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -1086,7 +1086,7 @@ class TestCalcExtractedVars:
                         "x": numpy.arange(4),
                     },
                     attrs={
-                        "standard_name": "PRMSL_meansealevel",
+                        "short_name": "PRMSL_meansealevel",
                         "long_name": "Pressure Reduced to MSL",
                         "units": "Pa",
                     },

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -298,7 +298,9 @@ class TestCalcDsChunks:
             "end date": "2015-01-02",
         }
         model_profile = {
-            "time coord": "time_counter",
+            "time coord": {
+                "name": "time_counter",
+            },
             "chunk size": {
                 "time": 1,
                 "depth": 40,
@@ -338,7 +340,9 @@ class TestCalcDsChunks:
             "end date": "2015-01-02",
         }
         model_profile = {
-            "time coord": "time_counter",
+            "time coord": {
+                "name": "time_counter",
+            },
             "chunk size": {
                 "time": 24,
                 "y": 266,
@@ -1179,9 +1183,15 @@ class TestCalcExtractedVars:
     @pytest.fixture(name="model_profile", scope="class")
     def fixture_model_profile(self):
         return {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 24,
                 "depth": 8,
@@ -1271,9 +1281,15 @@ class TestCalcExtractedVars:
             },
         }
         model_profile = {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 24,
                 "y": 5,

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -203,7 +203,7 @@ class TestCalcDsPaths:
                 "datasets": {
                     "day": {
                         "biology": {
-                            "file pattern": "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
+                            "file pattern": "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
                         },
                     },
                 },
@@ -229,7 +229,7 @@ class TestCalcDsPaths:
         assert log_output.entries[0]["vars_group"] == "biology"
         assert (
             log_output.entries[0]["nc_files_pattern"]
-            == "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
+            == "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc"
         )
         assert log_output.entries[0]["start_date"] == "2015-01-01"
         assert log_output.entries[0]["end_date"] == "2015-01-02"

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -363,6 +363,47 @@ class TestCalcDsChunks:
         assert log_output.entries[0]["chunk_size"] == expected
         assert log_output.entries[0]["event"] == "chunk size for dataset loading"
 
+    def test_model_profile_chunk_size_unchanged(self, log_output):
+        """Test to demonstrate bug whereby model profile chunk size dict was getting changed
+        in the course of calculating the dataset loading chunk size dict.
+        """
+        extract_config = {
+            "dataset": {
+                "time base": "day",
+                "variables group": "biology",
+            },
+            "start date": "2015-01-01",
+            "end date": "2015-01-02",
+        }
+        model_profile = {
+            "time coord": {
+                "name": "time_counter",
+            },
+            "chunk size": {
+                "time": 1,
+                "depth": 40,
+                "y": 898,
+                "x": 398,
+            },
+            "results archive": {
+                "datasets": {
+                    "day": {
+                        "biology": {"depth coord": "deptht"},
+                    },
+                },
+            },
+        }
+
+        extract.calc_ds_chunk_size(extract_config, model_profile)
+
+        expected = {
+            "time": 1,
+            "depth": 40,
+            "y": 898,
+            "x": 398,
+        }
+        assert model_profile["chunk size"] == expected
+
 
 class TestCreateDataarray:
     """Unit tests for create_dataarray() function."""

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -399,9 +399,15 @@ class TestCalcOutputCoords:
     @pytest.fixture(name="model_profile", scope="class")
     def fixture_model_profile(self):
         return {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 1,
                 "depth": 40,
@@ -541,9 +547,15 @@ class TestCalcOutputCoords:
 
     def test_no_depth_coord(self):
         model_profile = {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 24,
                 "y": 266,
@@ -774,9 +786,15 @@ class TestCalcOutputCoords:
             },
         )
         model_profile = {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 24,
                 "y": 5,
@@ -974,9 +992,15 @@ class TestCalcOutputCoords:
             }
         }
         model_profile = {
-            "time coord": "time_counter",
-            "y coord": "y",
-            "x coord": "x",
+            "time coord": {
+                "name": "time_counter",
+            },
+            "y coord": {
+                "name": "y",
+            },
+            "x coord": {
+                "name": "x",
+            },
             "chunk size": {
                 "time": 24,
                 "y": 5,

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -749,6 +749,73 @@ class TestCalcOutputCoords:
         assert log_output.entries[2]["log_level"] == "debug"
         assert log_output.entries[2]["event"] == "extraction y coordinate"
 
+    def test_y_index_coord_cast_to_int(self, log_output):
+        source_dataset = xarray.Dataset(
+            coords={
+                "time_counter": numpy.arange(4),
+                "y": numpy.arange(9, dtype=float),
+                "x": numpy.arange(4, dtype=float),
+            },
+            data_vars={
+                "atmpres": xarray.DataArray(
+                    name="atmpres",
+                    data=numpy.ones((4, 9, 4), dtype=numpy.single),
+                    coords={
+                        "time_counter": numpy.arange(4),
+                        "y": numpy.arange(9, dtype=float),
+                        "x": numpy.arange(4, dtype=float),
+                    },
+                    attrs={
+                        "short_name": "PRMSL_meansealevel",
+                        "long_name": "Pressure Reduced to MSL",
+                        "units": "Pa",
+                    },
+                ),
+            },
+        )
+        model_profile = {
+            "time coord": "time_counter",
+            "y coord": "y",
+            "x coord": "x",
+            "chunk size": {
+                "time": 24,
+                "y": 5,
+                "x": 4,
+            },
+            "extraction time origin": "2007-01-01",
+            "results archive": {
+                "datasets": {
+                    "hour": {
+                        "surface fields": {},
+                    }
+                }
+            },
+        }
+        extract_config = {
+            "dataset": {
+                "time base": "day",
+                "variables group": "biology",
+            }
+        }
+
+        output_coords = extract.calc_output_coords(
+            source_dataset, extract_config, model_profile
+        )
+
+        assert output_coords["gridY"].name == "gridY"
+        assert numpy.array_equal(output_coords["gridY"].data, source_dataset.y.data)
+        assert output_coords["gridY"].dtype == numpy.dtype(int)
+        assert output_coords["gridY"].attrs["standard_name"] == "y"
+        assert output_coords["gridY"].attrs["long_name"] == "Grid Y"
+        assert output_coords["gridY"].attrs["units"] == "count"
+        assert (
+            output_coords["gridY"].attrs["comment"]
+            == "gridY values are grid indices in the model y-direction"
+        )
+
+        assert log_output.entries[1]["log_level"] == "debug"
+        assert log_output.entries[1]["event"] == "extraction y coordinate"
+
     def test_y_index_coord_selection_y_min(
         self, source_dataset, model_profile, log_output
     ):
@@ -875,6 +942,73 @@ class TestCalcOutputCoords:
 
         assert log_output.entries[3]["log_level"] == "debug"
         assert log_output.entries[3]["event"] == "extraction x coordinate"
+
+    def test_x_index_coord_cast_to_int(self, log_output):
+        source_dataset = xarray.Dataset(
+            coords={
+                "time_counter": numpy.arange(4),
+                "y": numpy.arange(9, dtype=float),
+                "x": numpy.arange(4, dtype=float),
+            },
+            data_vars={
+                "atmpres": xarray.DataArray(
+                    name="atmpres",
+                    data=numpy.ones((4, 9, 4), dtype=numpy.single),
+                    coords={
+                        "time_counter": numpy.arange(4),
+                        "y": numpy.arange(9, dtype=float),
+                        "x": numpy.arange(4, dtype=float),
+                    },
+                    attrs={
+                        "short_name": "PRMSL_meansealevel",
+                        "long_name": "Pressure Reduced to MSL",
+                        "units": "Pa",
+                    },
+                ),
+            },
+        )
+        extract_config = {
+            "dataset": {
+                "time base": "day",
+                "variables group": "biology",
+            }
+        }
+        model_profile = {
+            "time coord": "time_counter",
+            "y coord": "y",
+            "x coord": "x",
+            "chunk size": {
+                "time": 24,
+                "y": 5,
+                "x": 4,
+            },
+            "extraction time origin": "2007-01-01",
+            "results archive": {
+                "datasets": {
+                    "hour": {
+                        "surface fields": {},
+                    }
+                }
+            },
+        }
+
+        output_coords = extract.calc_output_coords(
+            source_dataset, extract_config, model_profile
+        )
+
+        assert output_coords["gridX"].name == "gridX"
+        assert numpy.array_equal(output_coords["gridX"].data, source_dataset.x.data)
+        assert output_coords["gridX"].dtype == numpy.dtype(int)
+        assert output_coords["gridX"].attrs["standard_name"] == "x"
+        assert output_coords["gridX"].attrs["long_name"] == "Grid X"
+        assert output_coords["gridX"].attrs["units"] == "count"
+        assert (
+            output_coords["gridX"].attrs["comment"]
+            == "gridX values are grid indices in the model x-direction"
+        )
+
+        assert log_output.entries[2]["log_level"] == "debug"
+        assert log_output.entries[2]["event"] == "extraction x coordinate"
 
     def test_x_index_coord_selection_x_min(
         self, source_dataset, model_profile, log_output

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -791,9 +791,13 @@ class TestCalcOutputCoords:
             },
             "y coord": {
                 "name": "y",
+                "units": "metres",
+                "comment": "gridY values are distance in metres in the model y-direction from the south-west corner of the grid",
             },
             "x coord": {
                 "name": "x",
+                "units": "metres",
+                "comment": "gridX values are distance in metres in the model x-direction from the south-west corner of the grid",
             },
             "chunk size": {
                 "time": 24,
@@ -825,10 +829,10 @@ class TestCalcOutputCoords:
         assert output_coords["gridY"].dtype == numpy.dtype(int)
         assert output_coords["gridY"].attrs["standard_name"] == "y"
         assert output_coords["gridY"].attrs["long_name"] == "Grid Y"
-        assert output_coords["gridY"].attrs["units"] == "count"
+        assert output_coords["gridY"].attrs["units"] == "metres"
         assert (
             output_coords["gridY"].attrs["comment"]
-            == "gridY values are grid indices in the model y-direction"
+            == "gridY values are distance in metres in the model y-direction from the south-west corner of the grid"
         )
 
         assert log_output.entries[1]["log_level"] == "debug"
@@ -997,9 +1001,13 @@ class TestCalcOutputCoords:
             },
             "y coord": {
                 "name": "y",
+                "units": "metres",
+                "comment": "gridY values are distance in metres in the model y-direction from the south-west corner of the grid",
             },
             "x coord": {
                 "name": "x",
+                "units": "metres",
+                "comment": "gridX values are distance in metres in the model x-direction from the south-west corner of the grid",
             },
             "chunk size": {
                 "time": 24,
@@ -1025,10 +1033,10 @@ class TestCalcOutputCoords:
         assert output_coords["gridX"].dtype == numpy.dtype(int)
         assert output_coords["gridX"].attrs["standard_name"] == "x"
         assert output_coords["gridX"].attrs["long_name"] == "Grid X"
-        assert output_coords["gridX"].attrs["units"] == "count"
+        assert output_coords["gridX"].attrs["units"] == "metres"
         assert (
             output_coords["gridX"].attrs["comment"]
-            == "gridX values are grid indices in the model x-direction"
+            == "gridX values are distance in metres in the model x-direction from the south-west corner of the grid"
         )
 
         assert log_output.entries[2]["log_level"] == "debug"

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -87,27 +87,51 @@ class TestSalishSeaCast201812:
     @pytest.mark.parametrize(
         "var_group, file_pattern, depth_coord",
         (
-            ("auxiliary", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc", "deptht"),
-            ("biology", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc", "deptht"),
-            ("chemistry", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc", "deptht"),
+            (
+                "auxiliary",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc",
+                "deptht",
+            ),
+            (
+                "biology",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc",
+                "deptht",
+            ),
+            (
+                "chemistry",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_carp_T.nc",
+                "deptht",
+            ),
             (
                 "grazing and mortality",
-                "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_dia2_T.nc",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_dia2_T.nc",
                 "deptht",
             ),
             (
                 "physics tracers",
-                "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
                 "deptht",
             ),
-            ("u velocity", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_U.nc", "depthu"),
-            ("v velocity", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_V.nc", "depthv"),
+            (
+                "u velocity",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_U.nc",
+                "depthu",
+            ),
+            (
+                "v velocity",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_V.nc",
+                "depthv",
+            ),
             (
                 "vertical turbulence",
-                "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
                 "depthw",
             ),
-            ("w velocity", "SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc", "depthw"),
+            (
+                "w velocity",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
+                "depthw",
+            ),
         ),
     )
     def test_SalishSeaCast_201812_day_datasets(
@@ -123,27 +147,51 @@ class TestSalishSeaCast201812:
     @pytest.mark.parametrize(
         "var_group, file_pattern, depth_coord",
         (
-            ("auxiliary", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc", "deptht"),
-            ("biology", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc", "deptht"),
-            ("chemistry", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc", "deptht"),
+            (
+                "auxiliary",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc",
+                "deptht",
+            ),
+            (
+                "biology",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_ptrc_T.nc",
+                "deptht",
+            ),
+            (
+                "chemistry",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_carp_T.nc",
+                "deptht",
+            ),
             (
                 "physics tracers",
-                "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
                 "deptht",
             ),
             (
                 "primary production",
-                "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_prod_T.nc",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_prod_T.nc",
                 "deptht",
             ),
-            ("u velocity", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_U.nc", "depthu"),
-            ("v velocity", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_V.nc", "depthv"),
+            (
+                "u velocity",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_U.nc",
+                "depthu",
+            ),
+            (
+                "v velocity",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_V.nc",
+                "depthv",
+            ),
             (
                 "vertical turbulence",
-                "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
                 "depthw",
             ),
-            ("w velocity", "SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc", "depthw"),
+            (
+                "w velocity",
+                "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_grid_W.nc",
+                "depthw",
+            ),
         ),
     )
     def test_SalishSeaCast_201812_hour_datasets(

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -26,6 +26,7 @@ MODEL_PROFILES_DIR = Path(__file__).parent.parent / "model_profiles"
 MODEL_PROFILES = (
     Path("SalishSeaCast-201812.yaml"),
     Path("HRDPS-2.5km-operational.yaml"),
+    Path("HRDPS-2.5km-GEMLAM-pre22sep11.yaml"),
     Path("unused-variables.yaml"),
 )
 
@@ -95,6 +96,12 @@ class TestSalishSeaCast201812:
             "x": 398,
         }
         assert model_profile["chunk size"] == expected_chunk_size
+        assert (
+            model_profile["geo ref dataset"]["path"]
+            == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV17-02"
+        )
+        assert model_profile["geo ref dataset"]["y coord"] == "gridY"
+        assert model_profile["geo ref dataset"]["x coord"] == "gridX"
 
     @pytest.mark.parametrize(
         "var_group, file_pattern, depth_coord",
@@ -239,7 +246,39 @@ class TestHRDPS2_5kmOperational:
             model_profile["geo ref dataset"]["path"]
             == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaAtmosphereGridV1"
         )
+        assert model_profile["geo ref dataset"]["y coord"] == "gridY"
+        assert model_profile["geo ref dataset"]["x coord"] == "gridX"
         assert (
             dataset_hour["surface fields"]["file pattern"] == "ops_{nemo_yyyymmdd}.nc"
+        )
+        assert "depth coord" not in dataset_hour["surface fields"]
+
+
+class TestHRDPS2_5kmGEMLAM_pre22sep11:
+    """Test of contents of HRDPS-2.5km-GEMLAM-pre22sep11 model profile YAML."""
+
+    def test_HRDPS2_5kmGEMLAM_pre22sep11_dataset(self):
+        with (MODEL_PROFILES_DIR / "HRDPS-2.5km-GEMLAM-pre22sep11.yaml").open(
+            "rt"
+        ) as f:
+            model_profile = yaml.safe_load(f)
+        dataset_hour = model_profile["results archive"]["datasets"]["hour"]
+
+        assert model_profile["time coord"]["name"] == "time_counter"
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
+        assert (
+            model_profile["geo ref dataset"]["path"]
+            == "/results/forcing/atmospheric/GEM2.5/gemlam/gemlam_y2007m01d03.nc"
+        )
+        assert model_profile["geo ref dataset"]["y coord"] == "y"
+        assert model_profile["geo ref dataset"]["longitude var"] == "nav_lon"
+        assert model_profile["geo ref dataset"]["x coord"] == "x"
+        assert model_profile["geo ref dataset"]["latitude var"] == "nav_lat"
+        assert (
+            dataset_hour["surface fields"]["file pattern"]
+            == "gemlam_{nemo_yyyymmdd}.nc"
         )
         assert "depth coord" not in dataset_hour["surface fields"]

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -25,6 +25,7 @@ import yaml
 MODEL_PROFILES_DIR = Path(__file__).parent.parent / "model_profiles"
 MODEL_PROFILES = (
     Path("SalishSeaCast-201812.yaml"),
+    Path("HRDPS-2.5km-operational.yaml"),
     Path("unused-variables.yaml"),
 )
 
@@ -214,3 +215,31 @@ class TestSalishSeaCast201812:
 
         assert hour_datasets[var_group]["file pattern"] == file_pattern
         assert hour_datasets[var_group]["depth coord"] == depth_coord
+
+
+class TestHRDPS2_5kmOperational:
+    """Test of contents of HRDPS-2.5km-operational model profile YAML."""
+
+    def test_HRDPS2_5kmOperational_dataset(self):
+        with (MODEL_PROFILES_DIR / "HRDPS-2.5km-operational.yaml").open("rt") as f:
+            model_profile = yaml.safe_load(f)
+        dataset_hour = model_profile["results archive"]["datasets"]["hour"]
+
+        assert model_profile["y coord"]["units"] == "metres"
+        assert (
+            model_profile["y coord"]["comment"]
+            == "gridY values are distance in metres in the model y-direction from the south-west corner of the grid"
+        )
+        assert model_profile["x coord"]["units"] == "metres"
+        assert (
+            model_profile["x coord"]["comment"]
+            == "gridX values are distance in metres in the model x-direction from the south-west corner of the grid"
+        )
+        assert (
+            model_profile["geo ref dataset"]["path"]
+            == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaAtmosphereGridV1"
+        )
+        assert (
+            dataset_hour["surface fields"]["file pattern"] == "ops_{nemo_yyyymmdd}.nc"
+        )
+        assert "depth coord" not in dataset_hour["surface fields"]

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -27,6 +27,7 @@ MODEL_PROFILES = (
     Path("SalishSeaCast-201812.yaml"),
     Path("HRDPS-2.5km-operational.yaml"),
     Path("HRDPS-2.5km-GEMLAM-pre22sep11.yaml"),
+    Path("HRDPS-2.5km-GEMLAM-22sep11onward.yaml"),
     Path("unused-variables.yaml"),
 )
 
@@ -272,6 +273,36 @@ class TestHRDPS2_5kmGEMLAM_pre22sep11:
         assert (
             model_profile["geo ref dataset"]["path"]
             == "/results/forcing/atmospheric/GEM2.5/gemlam/gemlam_y2007m01d03.nc"
+        )
+        assert model_profile["geo ref dataset"]["y coord"] == "y"
+        assert model_profile["geo ref dataset"]["longitude var"] == "nav_lon"
+        assert model_profile["geo ref dataset"]["x coord"] == "x"
+        assert model_profile["geo ref dataset"]["latitude var"] == "nav_lat"
+        assert (
+            dataset_hour["surface fields"]["file pattern"]
+            == "gemlam_{nemo_yyyymmdd}.nc"
+        )
+        assert "depth coord" not in dataset_hour["surface fields"]
+
+
+class TestHRDPS2_5kmGEMLAM_22sep11onward:
+    """Test of contents of HRDPS-2.5km-GEMLAM-22sep11onward model profile YAML."""
+
+    def test_HRDPS2_5kmGEMLAM_22sep11onward_dataset(self):
+        with (MODEL_PROFILES_DIR / "HRDPS-2.5km-GEMLAM-22sep11onward.yaml").open(
+            "rt"
+        ) as f:
+            model_profile = yaml.safe_load(f)
+        dataset_hour = model_profile["results archive"]["datasets"]["hour"]
+
+        assert model_profile["time coord"]["name"] == "time_counter"
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
+        assert (
+            model_profile["geo ref dataset"]["path"]
+            == "/results/forcing/atmospheric/GEM2.5/gemlam/gemlam_y2011m09d22.nc"
         )
         assert model_profile["geo ref dataset"]["y coord"] == "y"
         assert model_profile["geo ref dataset"]["longitude var"] == "nav_lon"

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -45,11 +45,18 @@ class TestModelProfiles:
             model_profile = yaml.safe_load(f)
 
         assert model_profile["name"] is not None
+        assert model_profile["time coord"]["name"] is not None
+        assert model_profile["y coord"]["name"] is not None
+        assert model_profile["x coord"]["name"] is not None
+        assert model_profile["chunk size"] is not None
+        assert model_profile["geo ref dataset"] is not None
+        assert model_profile["geo ref dataset"]["path"] is not None
+        assert model_profile["geo ref dataset"]["y coord"] is not None
+        assert model_profile["geo ref dataset"]["x coord"] is not None
+        assert model_profile["extraction time origin"] is not None
         assert model_profile["results archive"] is not None
         assert model_profile["results archive"]["path"] is not None
         assert model_profile["results archive"]["datasets"] is not None
-        assert model_profile["time coord"] is not None
-        assert model_profile["chunk size"] is not None
 
     def test_unused_variables(self):
         with (MODEL_PROFILES_DIR / "unused-variables.yaml").open("rt") as f:
@@ -64,7 +71,7 @@ class TestModelProfiles:
 
 
 class TestSalishSeaCast201812:
-    """Test of contents of SalishSeaCast-201812 model profile YAML."""
+    """Tests of contents of SalishSeaCast-201812 model profile YAML."""
 
     def test_SalishSeaCast_201812(self):
         with (MODEL_PROFILES_DIR / "SalishSeaCast-201812.yaml").open("rt") as f:
@@ -75,7 +82,11 @@ class TestSalishSeaCast201812:
             model_profile["results archive"]["path"]
             == "/results/SalishSea/nowcast-green.201812/"
         )
-        assert model_profile["time coord"] == "time_counter"
+        assert model_profile["time coord"]["name"] == "time_counter"
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
+        assert "units" not in model_profile["y coord"]
+        assert "comment" not in model_profile["y coord"]
         expected_chunk_size = {
             "time": 1,
             "depth": 40,


### PR DESCRIPTION
Lots of adjustments to handle a dataset that isn't structured like SalishSeaCast NEMO datasets.
In particular:

* All files in one directory instead of separated into directory per day
* File name patterns that use NEMO forcing date convention; e.g. `y2022m03d21`
* Handle datasets without depth coordinate; HRDPS is surface forcing
* HRDPS uses `short_name` attribute for some variables instead of `standard_name`
* operational HRDPS y, x grid indices are metres from south-west corner of grid, stored as floats
* pre-operational HRDPS y, x grid indices are grid index counts from south-west corner of grid, stored as ints (like SalishSeaCast NEMO)
