### PR TITLE
Prevent KeyError when extraction variable not in variables group

### DIFF
--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -56,7 +56,7 @@ def extract(config_file, cli_start_date, cli_end_date):
     ds_paths = calc_ds_paths(config, model_profile)
     chunk_size = calc_ds_chunk_size(config, model_profile)
     dask_client = get_dask_client(config["dask cluster"])
-    with open_dataset(ds_paths, chunk_size, config, model_profile) as ds:
+    with open_dataset(ds_paths, chunk_size, config) as ds:
         logger.info("extracting variables")
         output_coords = calc_output_coords(ds, config, model_profile)
         extracted_vars = calc_extracted_vars(ds, output_coords, config, model_profile)
@@ -330,7 +330,7 @@ def get_dask_client(dask_config_yaml):
     return client
 
 
-def open_dataset(ds_paths, chunk_size, config, model_profile):
+def open_dataset(ds_paths, chunk_size, config):
     """Open a list of dataset paths as a single dataset.
 
     This is a wrapper around :py:func:`xarray.open_mfdataset` that ensures that the
@@ -345,8 +345,6 @@ def open_dataset(ds_paths, chunk_size, config, model_profile):
     :param dict chunk_size: Chunks size to use for loading datasets.
 
     :param dict config: Extraction processing configuration dictionary.
-
-    :param dict model_profile: Model profile dictionary.
 
     :return: Multi-file dataset.
     :rtype: :py:class:`xarray.Dataset`

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -348,6 +348,8 @@ def open_dataset(ds_paths, chunk_size, config):
 
     :return: Multi-file dataset.
     :rtype: :py:class:`xarray.Dataset`
+
+    :raises: :py:exc:`SystemExit` if multi-file dataset contains no variables.
     """
     unused_vars_yaml = (
         Path(__file__).parent.parent.parent / "model_profiles" / "unused-variables.yaml"
@@ -372,6 +374,13 @@ def open_dataset(ds_paths, chunk_size, config):
         drop_variables=drop_vars,
         parallel=True,
     )
+    if not ds.data_vars:
+        logger.error(
+            "no variables in source dataset",
+            extract_vars=extract_vars,
+            possible_reasons="typo in variable name, or incorrect variables group",
+        )
+        raise SystemExit(2)
     logger.debug("opened dataset", ds=ds)
     return ds
 


### PR DESCRIPTION
Confirm that opened multi-file dataset contains variables. If not. log error with suggested possible reasons.

Resolves #37