### PR TITLE
Add model profile descriptions

### DIFF
--- a/docs/model_profiles.rst
+++ b/docs/model_profiles.rst
@@ -50,6 +50,40 @@ etc.
 The default values are generally those associated with the SalishSeaCast NEMO model datasets.
 
 
+:py:attr:`description` Item (Required)
+--------------------------------------
+
+The description of the model profile.
+
+Example:
+
+.. code-block:: yaml
+
+   description: SalishSeaCast version 202111 NEMO results on storage accessible from salish.
+                2007-01-01 onward.
+
+Multi-paragraph descriptions are supported.
+Please note that all lines of the description are indented.
+
+.. code-block:: yaml
+
+   description: ECCC HRDPS (High Resolution Deterministic Prediction System)
+                2.5 km resolution GEMLAM pre-operational model product fields processed
+                for use as surface forcing fields for the SalishSeaCast models.
+
+                This model profile is for the SalishSeaCast NEMO forcing files generated
+                from the HRDPS model pre-operational period 2011-09-22 to 2014-11-18 product
+                fields provided from archives maintained by the ECCC Vancouver office.
+
+                For the HRDPS model product fields from the 2007-01-03 to 2011-09-21
+                pre-operational period please use the HRDPS-2.5km-GEMLAM-pre22sep11.yaml
+                profile.
+
+                For the HRDPS operational model product fields downloaded from the
+                ECCC Datamart servers daily from 2014-09-12 to present please use the
+                HRDPS-2.5km-operational.yaml profile.
+
+
 :py:attr:`name` Item (Deprecated)
 ---------------------------------
 

--- a/docs/model_profiles.rst
+++ b/docs/model_profiles.rst
@@ -50,8 +50,8 @@ etc.
 The default values are generally those associated with the SalishSeaCast NEMO model datasets.
 
 
-:py:attr:`name` Item (Required)
--------------------------------
+:py:attr:`name` Item (Deprecated)
+---------------------------------
 
 The name of the model profile.
 

--- a/model_profiles/HRDPS-2.5km-GEMLAM-22sep11onward.yaml
+++ b/model_profiles/HRDPS-2.5km-GEMLAM-22sep11onward.yaml
@@ -1,18 +1,18 @@
-# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
-# 2.5 km resolution GEMLAM pre-operational model product fields processed for use as
-# surface forcing fields for the SalishSeaCast models.
-#
-# This model profile is for the SalishSeaCast NEMO forcing files generated
-# from the HRDPS model pre-operational period 2011-09-22 to 2014-11-18 product fields
-# provided from archives maintained by the ECCC Vancouver office.
-#
-# For the HRDPS model product fields from the 2007-01-03 to 2011-09-21 pre-operational
-# period please use the HRDPS-2.5km-GEMLAM-pre22sep11.yaml profile.
-#
-# For the HRDPS operational model product fields downloaded from the ECCC Datamart servers
-# daily from 2014-09-12 to present please use the HRDPS-2.5km-operational.yaml profile.
+description: ECCC HRDPS (High Resolution Deterministic Prediction System)
+             2.5 km resolution GEMLAM pre-operational model product fields processed
+             for use as surface forcing fields for the SalishSeaCast models.
 
-name: HRDPS-2.5km-GEMLAM-22sep11onward
+             This model profile is for the SalishSeaCast NEMO forcing files generated
+             from the HRDPS model pre-operational period 2011-09-22 to 2014-11-18 product
+             fields provided from archives maintained by the ECCC Vancouver office.
+
+             For the HRDPS model product fields from the 2007-01-03 to 2011-09-21
+             pre-operational period please use the HRDPS-2.5km-GEMLAM-pre22sep11.yaml
+             profile.
+
+             For the HRDPS operational model product fields downloaded from the
+             ECCC Datamart servers daily from 2014-09-12 to present please use the
+             HRDPS-2.5km-operational.yaml profile.
 
 time coord:
   name: time_counter

--- a/model_profiles/HRDPS-2.5km-GEMLAM-pre22sep11.yaml
+++ b/model_profiles/HRDPS-2.5km-GEMLAM-pre22sep11.yaml
@@ -1,18 +1,18 @@
-# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
-# 2.5 km resolution GEMLAM pre-operational model product fields processed for use as
-# surface forcing fields for the SalishSeaCast models.
-#
-# This model profile is for the SalishSeaCast NEMO forcing files generated
-# from the HRDPS model pre-operational period 2007-01-03 to 2011-09-21 product fields
-# provided from archives maintained by the ECCC Vancouver office.
-#
-# For the HRDPS model product fields from the 2011-09-22 to 2014-11-18 pre-operational
-# period please use the HRDPS-2.5km-GEMLAM-22sep11onward.yaml profile.
-#
-# For the HRDPS operational model product fields downloaded from the ECCC Datamart servers
-# daily from 2014-09-12 to present please use the HRDPS-2.5km-operational.yaml profile.
+description: ECCC HRDPS (High Resolution Deterministic Prediction System)
+             2.5 km resolution GEMLAM pre-operational model product fields processed for
+             use as surface forcing fields for the SalishSeaCast models.
 
-name: HRDPS-2.5km-GEMLAM-pre22sep11
+             This model profile is for the SalishSeaCast NEMO forcing files generated from
+             the HRDPS model pre-operational period 2007-01-03 to 2011-09-21 product fields
+             provided from archives maintained by the ECCC Vancouver office.
+
+             For the HRDPS model product fields from the 2011-09-22 to 2014-11-18
+             pre-operational period please use the HRDPS-2.5km-GEMLAM-22sep11onward.yaml
+             profile.
+
+             For the HRDPS operational model product fields downloaded from the
+             ECCC Datamart servers daily from 2014-09-12 to present please use the
+             HRDPS-2.5km-operational.yaml profile.
 
 time coord:
   name: time_counter

--- a/model_profiles/HRDPS-2.5km-operational.yaml
+++ b/model_profiles/HRDPS-2.5km-operational.yaml
@@ -1,15 +1,16 @@
-# Reshapr model profile for ECCC HRDPS (High Resolution Deterministic Prediction System)
-# 2.5 km resolution operational model product fields processed for use as
-# surface forcing fields for the SalishSeaCast models
-#
-# This model profile is for the SalishSeaCast NEMO forcing files generated
-# from the HRDPS model product fields downloaded from the ECCC Datamart servers
-# daily from 2014-09-12 to present.
-# For the HRDPS model product fields from the pre-operational periods please use:
-#   2007-01-03 to 2011-09-21: the HRDPS-2.5km-GEMLAM-pre22sep11.yaml profile
-#   2011-09-22 to 2014-11-18: the HRDPS-2.5km-GEMLAM-22sep11onward.yaml profile
+description: ECCC HRDPS (High Resolution Deterministic Prediction System)
+             2.5 km resolution operational model product fields processed for use as
+             surface forcing fields for the SalishSeaCast models
 
-name: HRDPS-2.5km-operational
+             This model profile is for the SalishSeaCast NEMO forcing files generated
+             from the HRDPS model product fields downloaded from the ECCC Datamart servers
+             daily from 2014-09-12 to present.
+             For the HRDPS model product fields from the pre-operational periods please
+             use
+
+             2007-01-03 to 2011-09-21 - the HRDPS-2.5km-GEMLAM-pre22sep11.yaml profile
+
+             2011-09-22 to 2014-11-18 - the HRDPS-2.5km-GEMLAM-22sep11onward.yaml profile
 
 time coord:
   name: time_counter

--- a/model_profiles/SalishSeaCast-201812.yaml
+++ b/model_profiles/SalishSeaCast-201812.yaml
@@ -1,6 +1,5 @@
-# Reshapr model profile for SalishSeaCast version 201812 NEMO model results
-
-name: SalishSeaCast.201812
+description: SalishSeaCast version 201812 NEMO results on storage accessible from salish.
+             2015-01-01 to 2019-06-30.
 
 time coord:
   name: time_counter

--- a/model_profiles/SalishSeaCast-201905.yaml
+++ b/model_profiles/SalishSeaCast-201905.yaml
@@ -1,6 +1,5 @@
-# Reshapr model profile for SalishSeaCast version 201905 NEMO model results
-
-name: SalishSeaCast.201905
+description: SalishSeaCast version 201905 NEMO results on storage accessible from salish.
+             2007-01-01 onward.
 
 time coord:
   name: time_counter

--- a/model_profiles/SalishSeaCast-202111-2xrez-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-2xrez-salish.yaml
@@ -1,4 +1,3 @@
-name: SalishSeaCast.202111-2xrez-salish
 description: Double resolution run of SalishSeaCast version 202111 on storage accessible
              from salish. Physics only for 2017.
 

--- a/model_profiles/SalishSeaCast-202111-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-salish.yaml
@@ -1,5 +1,5 @@
-name: SalishSeaCast-202111-salish
-description: SalishSeaCast version 202111 on storage accessible from salish
+description: SalishSeaCast version 202111 NEMO results on storage accessible from salish.
+             2007-01-01 onward.
              **Preliminary for use during hindcast spin-up**
 
 time coord:

--- a/reshapr/core/info.py
+++ b/reshapr/core/info.py
@@ -112,13 +112,14 @@ def _model_profile_info(profile, time_interval, vars_group, console):
     console.print(f"[green]{profile_file}:", highlight=False)
     with (MODEL_PROFILES_PATH / profile_file).open("rt") as f:
         model_profile = yaml.safe_load(f)
-    description = textwrap.wrap(
-        model_profile["description"],
-        initial_indent="  ",
-        subsequent_indent="  ",
-    )
-    for line in description:
-        console.print(f"{line}", highlight=False)
+    description = model_profile["description"].splitlines()
+    for paragraph in description:
+        formatted = textwrap.wrap(
+            paragraph, initial_indent="  ", subsequent_indent="  "
+        )
+        for line in formatted:
+            console.print(f"{line}", highlight=False)
+        console.print()
 
     if time_interval and vars_group:
         _vars_list(model_profile, time_interval, vars_group, console)

--- a/reshapr/core/info.py
+++ b/reshapr/core/info.py
@@ -18,6 +18,7 @@
 """Provide information about reshapr, dask clusters, and model profiles.
 """
 import sys
+import textwrap
 from importlib import metadata
 from pathlib import Path
 
@@ -111,6 +112,13 @@ def _model_profile_info(profile, time_interval, vars_group, console):
     console.print(f"[green]{profile_file}:", highlight=False)
     with (MODEL_PROFILES_PATH / profile_file).open("rt") as f:
         model_profile = yaml.safe_load(f)
+    description = textwrap.wrap(
+        model_profile["description"],
+        initial_indent="  ",
+        subsequent_indent="  ",
+    )
+    for line in description:
+        console.print(f"{line}", highlight=False)
 
     if time_interval and vars_group:
         _vars_list(model_profile, time_interval, vars_group, console)

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -158,7 +158,9 @@ class TestLoadModelProfile:
 
         model_profile = extract._load_model_profile(model_profile_yaml)
 
-        assert model_profile["name"] == "SalishSeaCast.201812"
+        assert model_profile["description"].startswith(
+            "SalishSeaCast version 201812 NEMO results"
+        )
 
         assert log_output.entries[0]["log_level"] == "info"
         model_profiles_path = Path(__file__).parent.parent.parent / "model_profiles"

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -189,7 +189,7 @@ class TestModelProfileInfo:
             "vvl grid",
             "w velocity",
         ]
-        assert set(line.strip() for line in stdout_lines[4 : len(expected) + 4]) == set(
+        assert set(line.strip() for line in stdout_lines[5 : len(expected) + 5]) == set(
             expected
         )
 
@@ -201,10 +201,11 @@ class TestModelProfileInfo:
         ),
     )
     def test_missing_time_interval_or_var_group(
-        self, time_interval, vars_group, log_output
+        self, time_interval, vars_group, log_output, capsys
     ):
         info.info("SalishSeaCast-202111-salish", time_interval, vars_group)
 
+        capsys.readouterr()
         assert log_output.entries[0]["log_level"] == "error"
         assert log_output.entries[0]["time_interval"] == time_interval
         assert log_output.entries[0]["vars_group"] == vars_group

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -189,7 +189,7 @@ class TestModelProfileInfo:
             "vvl grid",
             "w velocity",
         ]
-        assert set(line.strip() for line in stdout_lines[5 : len(expected) + 5]) == set(
+        assert set(line.strip() for line in stdout_lines[6 : len(expected) + 6]) == set(
             expected
         )
 

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -153,8 +153,8 @@ class TestModelProfileInfo:
     @pytest.mark.parametrize(
         "model_profile, expected",
         (
-            ("SalishSeaCast-201905", "SalishSeaCast-201905.yaml:"),
-            ("SalishSeaCast-201905.yaml", "SalishSeaCast-201905.yaml:"),
+            ("SalishSeaCast-202111-salish", "SalishSeaCast-202111-salish.yaml:"),
+            ("SalishSeaCast-202111-salish.yaml", "SalishSeaCast-202111-salish.yaml:"),
         ),
     )
     def test_model_profile_file_name(self, model_profile, expected, capsys):
@@ -163,29 +163,33 @@ class TestModelProfileInfo:
         stdout_lines = capsys.readouterr().out.splitlines()
         assert stdout_lines[0] == expected
 
+    def test_model_profile_file_description(self, capsys):
+        info.info("SalishSeaCast-202111-salish", time_interval="", vars_group="")
+
+        stdout_lines = capsys.readouterr().out.splitlines()
+        assert stdout_lines[1].startswith("  SalishSeaCast version 202111")
+
     def test_time_bases_and_var_groups(self, capsys):
-        info.info("SalishSeaCast-201905", time_interval="", vars_group="")
+        info.info("SalishSeaCast-202111-salish", time_interval="", vars_group="")
 
         stdout_lines = capsys.readouterr().out.splitlines()
         expected = [
             "day",
-            "auxiliary",
-            "biology",
-            "biology and chemistry rates",
-            "chemistry",
-            "grazing and mortality",
-            "physics tracers",
+            "biology growth rates",
+            "grazing",
+            "mortality",
             "hour",
-            "auxiliary",
             "biology",
             "chemistry",
+            "light",
             "physics tracers",
+            "turbulence",
             "u velocity",
             "v velocity",
-            "vertical turbulence",
+            "vvl grid",
             "w velocity",
         ]
-        assert set(line.strip() for line in stdout_lines[2 : len(expected) + 2]) == set(
+        assert set(line.strip() for line in stdout_lines[4 : len(expected) + 4]) == set(
             expected
         )
 
@@ -199,7 +203,7 @@ class TestModelProfileInfo:
     def test_missing_time_interval_or_var_group(
         self, time_interval, vars_group, log_output
     ):
-        info.info("SalishSeaCast-201905", time_interval, vars_group)
+        info.info("SalishSeaCast-202111-salish", time_interval, vars_group)
 
         assert log_output.entries[0]["log_level"] == "error"
         assert log_output.entries[0]["time_interval"] == time_interval

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -93,7 +93,9 @@ class TestSalishSeaCast201812:
         with (MODEL_PROFILES_DIR / "SalishSeaCast-201812.yaml").open("rt") as f:
             model_profile = yaml.safe_load(f)
 
-        assert model_profile["name"] == "SalishSeaCast.201812"
+        assert model_profile["description"].startswith(
+            "SalishSeaCast version 201812 NEMO results"
+        )
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
         assert "units" not in model_profile["y coord"]
@@ -248,7 +250,10 @@ class TestSalishSeaCast201905:
         with (MODEL_PROFILES_DIR / "SalishSeaCast-201905.yaml").open("rt") as f:
             model_profile = yaml.safe_load(f)
 
-        assert model_profile["name"] == "SalishSeaCast.201905"
+        assert model_profile["description"] == (
+            "SalishSeaCast version 201905 NEMO results on storage accessible from salish. "
+            "2007-01-01 onward."
+        )
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
         assert "units" not in model_profile["y coord"]
@@ -384,7 +389,7 @@ class TestSalishSeaCast202111:
             model_profile = yaml.safe_load(f)
 
         assert model_profile["description"].startswith(
-            "SalishSeaCast version 202111 on storage accessible from salish"
+            "SalishSeaCast version 202111 NEMO results on storage accessible from salish"
         )
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
@@ -512,7 +517,6 @@ class TestSalishSeaCast202111_2xrezSalish:
         ) as f:
             model_profile = yaml.safe_load(f)
 
-        assert model_profile["name"] == "SalishSeaCast.202111-2xrez-salish"
         assert model_profile["description"] == (
             "Double resolution run of SalishSeaCast version 202111 on storage accessible "
             "from salish. Physics only for 2017."
@@ -591,7 +595,11 @@ class TestHRDPS2_5kmOperational:
             model_profile = yaml.safe_load(f)
         dataset_hour = model_profile["results archive"]["datasets"]["hour"]
 
-        assert model_profile["name"] == "HRDPS-2.5km-operational"
+        expected = (
+            "HRDPS model product fields downloaded from the ECCC Datamart servers daily "
+            "from 2014-09-12 to present"
+        )
+        assert expected in model_profile["description"]
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
         assert model_profile["y coord"]["units"] == "metres"
@@ -638,7 +646,10 @@ class TestHRDPS2_5kmGEMLAM_pre22sep11:
             model_profile = yaml.safe_load(f)
         dataset_hour = model_profile["results archive"]["datasets"]["hour"]
 
-        assert model_profile["name"] == "HRDPS-2.5km-GEMLAM-pre22sep11"
+        expected = (
+            "HRDPS model pre-operational period 2007-01-03 to 2011-09-21 product fields"
+        )
+        assert expected in model_profile["description"]
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
         assert "units" not in model_profile["y coord"]
@@ -678,7 +689,8 @@ class TestHRDPS2_5kmGEMLAM_22sep11onward:
             model_profile = yaml.safe_load(f)
         dataset_hour = model_profile["results archive"]["datasets"]["hour"]
 
-        assert model_profile["name"] == "HRDPS-2.5km-GEMLAM-22sep11onward"
+        expected = "HRDPS model pre-operational period 2011-09-22 to 2014-11-18 product"
+        assert expected in model_profile["description"]
         assert model_profile["time coord"]["name"] == "time_counter"
         assert model_profile["y coord"]["name"] == "y"
         assert "units" not in model_profile["y coord"]

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -51,7 +51,6 @@ class TestModelProfiles:
         with (MODEL_PROFILES_DIR / model_profile_yaml).open("rt") as f:
             model_profile = yaml.safe_load(f)
 
-        assert model_profile["name"] is not None
         assert model_profile["time coord"]["name"] is not None
         assert model_profile["y coord"]["name"] is not None
         assert model_profile["x coord"]["name"] is not None
@@ -383,7 +382,6 @@ class TestSalishSeaCast202111:
         with (MODEL_PROFILES_DIR / "SalishSeaCast-202111-salish.yaml").open("rt") as f:
             model_profile = yaml.safe_load(f)
 
-        assert model_profile["name"] == "SalishSeaCast-202111-salish"
         assert model_profile["description"].startswith(
             "SalishSeaCast version 202111 on storage accessible from salish"
         )

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -51,6 +51,7 @@ class TestModelProfiles:
         with (MODEL_PROFILES_DIR / model_profile_yaml).open("rt") as f:
             model_profile = yaml.safe_load(f)
 
+        assert model_profile["description"] is not None
         assert model_profile["time coord"]["name"] is not None
         assert model_profile["y coord"]["name"] is not None
         assert model_profile["x coord"]["name"] is not None


### PR DESCRIPTION
`description` item is now required in all model profile YAML files. It's value is a text blob that describes the profile. The text can be multi-line and multi-paragraph. The description is displayed in the output from the `reshapr info model-profile` command.

The model description `name` item is deprecated.

`description` items have been added to all model profiles. 