### PR TITLE
Update SalishSeaCast-202111-salish model profile

### DIFF
--- a/model_profiles/SalishSeaCast-202111-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-salish.yaml
@@ -1,6 +1,5 @@
 description: SalishSeaCast version 202111 NEMO results on storage accessible from salish.
              2007-01-01 onward.
-             **Preliminary for use during hindcast spin-up**
 
 time coord:
   name: time_counter
@@ -25,8 +24,7 @@ geo ref dataset:
   y coord: gridY
   x coord: gridX
 
-# TODO: update to 2007-01-01 after spin-up is finished
-extraction time origin: 2002-01-01
+extraction time origin: 2007-01-01
 
 results archive:
   path: /results2/SalishSea/nowcast-green.202111/

--- a/model_profiles/SalishSeaCast-202111-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-salish.yaml
@@ -13,7 +13,7 @@ x coord:
 # They are replaced with actual coordinate names in files in the code;
 # e.g. time is replaced by time_counter for dataset loading
 chunk size:
-  time: 1
+  time: 24
   depth: 40
   y: 898
   x: 398

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -189,7 +189,7 @@ class TestModelProfileInfo:
             "vvl grid",
             "w velocity",
         ]
-        assert set(line.strip() for line in stdout_lines[6 : len(expected) + 6]) == set(
+        assert set(line.strip() for line in stdout_lines[5 : len(expected) + 5]) == set(
             expected
         )
 

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -399,7 +399,7 @@ class TestSalishSeaCast202111:
         assert "units" not in model_profile["x coord"]
         assert "comment" not in model_profile["x coord"]
         expected_chunk_size = {
-            "time": 1,
+            "time": 24,
             "depth": 40,
             "y": 898,
             "x": 398,

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -411,7 +411,7 @@ class TestSalishSeaCast202111:
         )
         assert model_profile["geo ref dataset"]["y coord"] == "gridY"
         assert model_profile["geo ref dataset"]["x coord"] == "gridX"
-        assert model_profile["extraction time origin"] == arrow.get("2002-01-01").date()
+        assert model_profile["extraction time origin"] == arrow.get("2007-01-01").date()
         assert (
             model_profile["results archive"]["path"]
             == "/results2/SalishSea/nowcast-green.202111/"


### PR DESCRIPTION
* Drop reference to spin-up from description and change extraction time origin
to beginning of hindcast period.
* Tests found that time chunk size of 24 gives better performance on salish than
1 for extractions from hour-average files, and it doesn't harm performance of
extractions from day-average files.