### PR TITLE
Add `use model coords` option to extraction

### DIFF
--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -488,8 +488,9 @@ def calc_output_coords(source_dataset, config, model_profile):
     * :kbd:`y_index`: :kbd:`gridY`
     * :kbd:`x_index`: :kbd:`gridX`
 
-    except if :kbd:`output model coords: True` is set in the extraction configuration,
-    in which case the output coordinates will be the same as the model coordinates.
+    except if :kbd:`extracted dataset: use model coords: True` is set in the
+    extraction configuration, in which case the output coordinates will be the same as the
+    model coordinates.
 
     :param source_dataset: Dataset from which variables are being extracted.
     :type source_dataset: :py:class:`xarray.Dataset`
@@ -501,12 +502,12 @@ def calc_output_coords(source_dataset, config, model_profile):
     :return: Mapping of coordinate names to their data arrays.
     :rtype: dict
     """
-    output_model_coords = config.get("output model coords", False)
+    use_model_coords = config["extracted dataset"].get("use model coords", False)
     time_interval = config.get("selection", {}).get("time interval", 1)
     # stop=None in slice() means the length of the array without having to know what that is
     time_selector = {model_profile["time coord"]["name"]: slice(0, None, time_interval)}
     output_time_coord_name = (
-        "time" if not output_model_coords else model_profile["time coord"]["name"]
+        "time" if not use_model_coords else model_profile["time coord"]["name"]
     )
     times = create_dataarray(
         output_time_coord_name,
@@ -548,9 +549,7 @@ def calc_output_coords(source_dataset, config, model_profile):
                 config.get("selection", {}).get("depth", {}).get("depth interval", 1)
             )
             depth_selector = slice(depth_min, depth_max, depth_interval)
-            output_depth_coord_name = (
-                "depth" if not output_model_coords else depth_coord
-            )
+            output_depth_coord_name = "depth" if not use_model_coords else depth_coord
             depths = create_dataarray(
                 output_depth_coord_name,
                 source_dataset[depth_coord].isel({depth_coord: depth_selector}),
@@ -569,7 +568,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     y_selector = slice(y_min, y_max, y_interval)
     y_coord = model_profile["y coord"]["name"]
     output_y_coord_name = (
-        "gridY" if not output_model_coords else model_profile["y coord"]["name"]
+        "gridY" if not use_model_coords else model_profile["y coord"]["name"]
     )
     y_indices = create_dataarray(
         output_y_coord_name,
@@ -592,7 +591,7 @@ def calc_output_coords(source_dataset, config, model_profile):
     x_selector = slice(x_min, x_max, x_interval)
     x_coord = model_profile["x coord"]["name"]
     output_x_coord_name = (
-        "gridX" if not output_model_coords else model_profile["x coord"]["name"]
+        "gridX" if not use_model_coords else model_profile["x coord"]["name"]
     )
     x_indices = create_dataarray(
         output_x_coord_name,

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -728,6 +728,8 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
             model_profile["x coord"]["name"]: x_selector,
         }
     extracted_vars = []
+    use_model_coords = config["extracted dataset"].get("use model coords", False)
+    output_depth_coord = "depth" if not use_model_coords else depth_coord
     for name, var in source_dataset.data_vars.items():
         var_selector = (
             selector
@@ -744,7 +746,7 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
             else {
                 c_name: c_selector
                 for c_name, c_selector in output_coords.items()
-                if c_name != "depth"
+                if c_name != output_depth_coord
             }
         )
         try:

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -968,7 +968,7 @@ def calc_coord_encoding(ds, coord, config, model_profile):
     :rtype: dict
     """
     match coord:
-        case "time":
+        case "time" | "time_counter":
             extract_time_origin = model_profile["extraction time origin"]
             match config["dataset"]["time base"]:
                 case "day":
@@ -987,7 +987,7 @@ def calc_coord_encoding(ds, coord, config, model_profile):
                 "zlib": config["extracted dataset"].get("deflate", True),
                 "_FillValue": None,
             }
-        case "depth":
+        case "depth" | "deptht" | "depthu" | "depthv" | "depthw":
             return {
                 "dtype": numpy.single,
                 "chunksizes": (ds.coords[coord].size,),

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -2401,14 +2401,22 @@ class TestCalcCoordEncoding:
     """Unit tests for calc_coord_encoding() function."""
 
     @pytest.mark.parametrize(
-        "time_base, quanta, time_offset",
+        "coord_name, time_base, quanta, time_offset",
         (
-            ("day", "days", "12:00:00"),
-            ("hour", "hours", "00:30:00"),
-            ("fortnight", "seconds", "00:30:00"),  # wildcard pattern test
+            ("time", "day", "days", "12:00:00"),
+            ("time", "hour", "hours", "00:30:00"),
+            ("time", "fortnight", "seconds", "00:30:00"),  # wildcard pattern test
+            ("time_counter", "day", "days", "12:00:00"),
+            ("time_counter", "hour", "hours", "00:30:00"),
+            (
+                "time_counter",
+                "fortnight",
+                "seconds",
+                "00:30:00",
+            ),  # wildcard pattern test
         ),
     )
-    def test_time_coord(self, time_base, quanta, time_offset):
+    def test_time_coord(self, coord_name, time_base, quanta, time_offset):
         dataset = xarray.Dataset()
         config = {
             "dataset": {
@@ -2418,7 +2426,9 @@ class TestCalcCoordEncoding:
         }
         model_profile = {"extraction time origin": "2015-01-01"}
 
-        encoding = extract.calc_coord_encoding(dataset, "time", config, model_profile)
+        encoding = extract.calc_coord_encoding(
+            dataset, coord_name, config, model_profile
+        )
 
         expected = {
             "dtype": numpy.single,
@@ -2450,17 +2460,33 @@ class TestCalcCoordEncoding:
         }
         assert encoding == expected
 
-    @pytest.mark.parametrize("deflate", (True, False))
-    def test_depth_coord(self, deflate):
+    @pytest.mark.parametrize(
+        "coord_name, deflate",
+        (
+            ("depth", True),
+            ("depth", False),
+            ("deptht", True),
+            ("deptht", False),
+            ("depthu", True),
+            ("depthu", False),
+            ("depthv", True),
+            ("depthv", False),
+            ("depthw", True),
+            ("depthw", False),
+        ),
+    )
+    def test_depth_coord(self, coord_name, deflate):
         dataset = xarray.Dataset(
             coords={
-                "depth": numpy.arange(0, 4, 0.5),
+                coord_name: numpy.arange(0, 4, 0.5),
             }
         )
         config = {"extracted dataset": {"deflate": deflate}}
         model_profile = {}
 
-        encoding = extract.calc_coord_encoding(dataset, "depth", config, model_profile)
+        encoding = extract.calc_coord_encoding(
+            dataset, coord_name, config, model_profile
+        )
 
         expected = {
             "dtype": numpy.single,
@@ -2476,6 +2502,10 @@ class TestCalcCoordEncoding:
             ("gridY", False),
             ("gridX", True),
             ("gridX", False),
+            ("y", True),
+            ("y", False),
+            ("x", True),
+            ("x", False),
         ),
     )
     def test_grid_index_coord(self, grid_index, deflate):

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -2571,6 +2571,11 @@ class TestCalcVarEncoding:
             "gridX": numpy.arange(4),
         }
         config = {"extracted dataset": {"deflate": deflate}}
+        model_profile = {
+            "time coord": {
+                "name": "time",
+            },
+        }
         var = xarray.DataArray(
             name="diatoms",
             data=numpy.empty((2, 8, 9, 4), dtype=numpy.single),
@@ -2582,12 +2587,45 @@ class TestCalcVarEncoding:
             },
         )
 
-        encoding = extract.calc_var_encoding(var, output_coords, config)
+        encoding = extract.calc_var_encoding(var, output_coords, config, model_profile)
 
         expected = {
             "dtype": numpy.single,
             "chunksizes": (1, 8, 9, 4),
             "zlib": deflate,
+        }
+        assert encoding == expected
+
+    def test_4d_var_model_coords(self):
+        output_coords = {
+            "time_counter": numpy.arange(2),
+            "deptht": numpy.arange(0, 4, 0.5),
+            "y": numpy.arange(9),
+            "x": numpy.arange(4),
+        }
+        config = {"extracted dataset": {"use model coords": True}}
+        model_profile = {
+            "time coord": {
+                "name": "time_counter",
+            },
+        }
+        var = xarray.DataArray(
+            name="diatoms",
+            data=numpy.empty((2, 8, 9, 4), dtype=numpy.single),
+            coords={
+                "time_counter": numpy.arange(2),
+                "deptht": numpy.arange(0, 4, 0.5),
+                "y": numpy.arange(9),
+                "x": numpy.arange(4),
+            },
+        )
+
+        encoding = extract.calc_var_encoding(var, output_coords, config, model_profile)
+
+        expected = {
+            "dtype": numpy.single,
+            "chunksizes": (1, 8, 9, 4),
+            "zlib": True,
         }
         assert encoding == expected
 
@@ -2600,6 +2638,11 @@ class TestCalcVarEncoding:
             "gridX": numpy.arange(4),
         }
         config = {"extracted dataset": {"deflate": deflate}}
+        model_profile = {
+            "time coord": {
+                "name": "time",
+            },
+        }
         var = xarray.DataArray(
             name="longitude",
             data=numpy.empty((9, 4), dtype=numpy.single),
@@ -2609,7 +2652,7 @@ class TestCalcVarEncoding:
             },
         )
 
-        encoding = extract.calc_var_encoding(var, output_coords, config)
+        encoding = extract.calc_var_encoding(var, output_coords, config, model_profile)
 
         expected = {
             "dtype": numpy.single,

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -758,7 +758,7 @@ class TestCalcOutputCoords:
         )
 
     @pytest.mark.parametrize(
-        "output_model_coords, coord_name, time_base, example",
+        "use_model_coords, coord_name, time_base, example",
         (
             (
                 True,
@@ -788,7 +788,7 @@ class TestCalcOutputCoords:
     )
     def test_time_coord(
         self,
-        output_model_coords,
+        use_model_coords,
         coord_name,
         time_base,
         example,
@@ -801,7 +801,9 @@ class TestCalcOutputCoords:
                 "time base": time_base,
                 "variables group": "biology",
             },
-            "output model coords": output_model_coords,
+            "extracted dataset": {
+                "use model coords": use_model_coords,
+            },
         }
 
         output_coords = extract.calc_output_coords(
@@ -850,6 +852,7 @@ class TestCalcOutputCoords:
             "selection": {
                 "time interval": 3,
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -875,14 +878,14 @@ class TestCalcOutputCoords:
         assert log_output.entries[0]["event"] == "extraction time coordinate"
 
     @pytest.mark.parametrize(
-        "output_model_coords, time_coord_name, y_coord_name, x_coord_name",
+        "use_model_coords, time_coord_name, y_coord_name, x_coord_name",
         (
             (True, "time_counter", "y", "x"),
             (False, "time", "gridY", "gridX"),
         ),
     )
     def test_no_depth_coord(
-        self, output_model_coords, time_coord_name, y_coord_name, x_coord_name
+        self, use_model_coords, time_coord_name, y_coord_name, x_coord_name
     ):
         model_profile = {
             "time coord": {
@@ -936,7 +939,9 @@ class TestCalcOutputCoords:
                 "time base": "hour",
                 "variables group": "surface fields",
             },
-            "output model coords": output_model_coords,
+            "extracted dataset": {
+                "use model coords": use_model_coords,
+            },
         }
 
         output_coords = extract.calc_output_coords(
@@ -978,7 +983,8 @@ class TestCalcOutputCoords:
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
-            }
+            },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -988,21 +994,23 @@ class TestCalcOutputCoords:
         assert "depth" not in output_coords
 
     @pytest.mark.parametrize(
-        "output_model_coords, coord_name",
+        "use_model_coords, coord_name",
         (
             (True, "deptht"),
             (False, "depth"),
         ),
     )
     def test_depth_coord(
-        self, output_model_coords, coord_name, source_dataset, model_profile, log_output
+        self, use_model_coords, coord_name, source_dataset, model_profile, log_output
     ):
         extract_config = {
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
             },
-            "output model coords": output_model_coords,
+            "extracted dataset": {
+                "use model coords": use_model_coords,
+            },
         }
 
         output_coords = extract.calc_output_coords(
@@ -1032,6 +1040,7 @@ class TestCalcOutputCoords:
                     "depth min": 5,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1056,6 +1065,7 @@ class TestCalcOutputCoords:
                     "depth max": 5,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1078,6 +1088,7 @@ class TestCalcOutputCoords:
                     "depth interval": 2,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1092,21 +1103,23 @@ class TestCalcOutputCoords:
         )
 
     @pytest.mark.parametrize(
-        "output_model_coords, coord_name",
+        "use_model_coords, coord_name",
         (
             (True, "y"),
             (False, "gridY"),
         ),
     )
     def test_y_index_coord(
-        self, output_model_coords, coord_name, source_dataset, model_profile, log_output
+        self, use_model_coords, coord_name, source_dataset, model_profile, log_output
     ):
         extract_config = {
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
             },
-            "output model coords": output_model_coords,
+            "extracted dataset": {
+                "use model coords": use_model_coords,
+            },
         }
 
         output_coords = extract.calc_output_coords(
@@ -1182,7 +1195,8 @@ class TestCalcOutputCoords:
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
-            }
+            },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1216,6 +1230,7 @@ class TestCalcOutputCoords:
                     "y min": 6,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1250,6 +1265,7 @@ class TestCalcOutputCoords:
                     "y max": 3,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1284,6 +1300,7 @@ class TestCalcOutputCoords:
                     "y interval": 2,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1306,21 +1323,23 @@ class TestCalcOutputCoords:
         assert log_output.entries[2]["event"] == "extraction y coordinate"
 
     @pytest.mark.parametrize(
-        "output_model_coords, coord_name",
+        "use_model_coords, coord_name",
         (
             (True, "x"),
             (False, "gridX"),
         ),
     )
     def test_x_index_coord(
-        self, output_model_coords, coord_name, source_dataset, model_profile, log_output
+        self, use_model_coords, coord_name, source_dataset, model_profile, log_output
     ):
         extract_config = {
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
             },
-            "output model coords": output_model_coords,
+            "extracted dataset": {
+                "use model coords": use_model_coords,
+            },
         }
 
         output_coords = extract.calc_output_coords(
@@ -1368,7 +1387,8 @@ class TestCalcOutputCoords:
             "dataset": {
                 "time base": "day",
                 "variables group": "biology",
-            }
+            },
+            "extracted dataset": {},
         }
         model_profile = {
             "time coord": {
@@ -1430,6 +1450,7 @@ class TestCalcOutputCoords:
                     "x min": 1,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1465,6 +1486,7 @@ class TestCalcOutputCoords:
                     "x max": 3,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(
@@ -1499,6 +1521,7 @@ class TestCalcOutputCoords:
                     "x interval": 2,
                 },
             },
+            "extracted dataset": {},
         }
 
         output_coords = extract.calc_output_coords(


### PR DESCRIPTION
Set an extraction configuration item `extracted dataset: use model coords: True` to cause the extracted dataset to use model coordinate names instead of the defaults (time, depth, gridY, gridX). This is primarily intended for use by the SalishSeaNowcast make_averaged_dataset worker which needs to be able to produce day-averaged datasets that have the same coordinate names as the hour-averaged ones that they are down-sampled from.