### PR TITLE
Add day-avg variable groups to SSC-202111 profile

### DIFF
--- a/model_profiles/SalishSeaCast-202111-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-salish.yaml
@@ -30,22 +30,30 @@ results archive:
   path: /results2/SalishSea/nowcast-green.202111/
   datasets:
     day:
+      biology:
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_biol_T.nc"
+        depth coord: deptht
+      chemistry:
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_chem_T.nc"
+        depth coord: deptht
       biology growth rates:
         file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_prod_T.nc"
         depth coord: deptht
       grazing:
         file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_graz_T.nc"
         depth coord: deptht
+      light:
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_chem_T.nc"
+        depth coord: deptht
       mortality:
         file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_graz_T.nc"
         depth coord: deptht
-      # TODO: add other groups from files produced by day averaging of hour-avg files
-      #       by post-download worker
-      # biology:
-      # chemistry:
-      # light:
-      # physics tracers:
-      # vvl grid:
+      physics tracers:
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
+        depth coord: deptht
+      vvl grid:
+        file pattern: "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc"
+        depth coord: deptht
     hour:
       biology:
         file pattern: "{ddmmmyy}/SalishSea_1h_{yyyymmdd}_{yyyymmdd}_biol_T.nc"

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -175,9 +175,14 @@ class TestModelProfileInfo:
         stdout_lines = capsys.readouterr().out.splitlines()
         expected = [
             "day",
+            "biology",
             "biology growth rates",
+            "chemistry",
             "grazing",
+            "light",
             "mortality",
+            "physics tracers",
+            "vvl grid",
             "hour",
             "biology",
             "chemistry",

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -421,8 +421,18 @@ class TestSalishSeaCast202111:
         "var_group, file_pattern, depth_coord",
         (
             (
+                "biology",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_biol_T.nc",
+                "deptht",
+            ),
+            (
                 "biology growth rates",
                 "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_prod_T.nc",
+                "deptht",
+            ),
+            (
+                "chemistry",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_chem_T.nc",
                 "deptht",
             ),
             (
@@ -431,8 +441,23 @@ class TestSalishSeaCast202111:
                 "deptht",
             ),
             (
+                "light",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_chem_T.nc",
+                "deptht",
+            ),
+            (
                 "mortality",
                 "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_graz_T.nc",
+                "deptht",
+            ),
+            (
+                "physics tracers",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
+                "deptht",
+            ),
+            (
+                "vvl grid",
+                "{ddmmmyy}/SalishSea_1d_{yyyymmdd}_{yyyymmdd}_grid_T.nc",
                 "deptht",
             ),
         ),


### PR DESCRIPTION
Day-averaged biology, chemistry & physics dataset files are calculated as part of run post-processing by SalishSeaNowcast make_averaged_dataset worker.