### PR TITLE
Replace deprecated loffset parameter in resample()

### DIFF
--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -2274,7 +2274,7 @@ class TestResample:
                 ),
             },
         )
-        assert resampled_ds.time == expected
+        xarray.testing.assert_equal(resampled_ds.time, expected)
         assert resampled_ds.time.attrs == expected.attrs
 
         assert log_output.entries[1]["log_level"] == "debug"
@@ -2362,7 +2362,7 @@ class TestResample:
                 ),
             },
         )
-        assert resampled_ds.time_counter == expected
+        xarray.testing.assert_equal(resampled_ds.time_counter, expected)
         assert resampled_ds.time_counter.attrs == expected.attrs
 
         assert log_output.entries[1]["log_level"] == "debug"
@@ -2450,7 +2450,7 @@ class TestResample:
                 ),
             },
         )
-        assert resampled_ds.time == expected
+        xarray.testing.assert_equal(resampled_ds.time, expected)
         assert resampled_ds.time.attrs == expected.attrs
 
         assert log_output.entries[1]["log_level"] == "debug"
@@ -2471,7 +2471,7 @@ class TestResample:
             data_vars={
                 "diatoms": xarray.DataArray(
                     name="diatoms",
-                    data=numpy.empty((30, 8, 9, 4), dtype=numpy.single),
+                    data=numpy.ones((30, 8, 9, 4), dtype=numpy.single),
                     coords={
                         "time_counter": pandas.date_range(
                             "2015-04-01",
@@ -2545,7 +2545,7 @@ class TestResample:
                 ),
             },
         )
-        assert resampled_ds.time_counter == expected
+        xarray.testing.assert_equal(resampled_ds.time_counter, expected)
         assert resampled_ds.time_counter.attrs == expected.attrs
 
         assert log_output.entries[1]["log_level"] == "debug"


### PR DESCRIPTION
Replace the deprecated `loffset` parameter in `dataset.resample()` in the extract.py module. Instead, a time_offset variable is computed and added to the corresponding time coordinate of the resampled dataset. This fixes potential future issues due to `loffset` deprecation.

re: issue #82

This fix came from https://github.com/pydata/xarray/discussions/8175.

Unit tests were also improved. For better results comparison, assertions in the testing module were changed to `xarray.testing.assert_equal()`. The data array was also changed from `numpy.empty()` to `numpy.ones()` for relevant tests.