### PR TITLE
Add fallback to use variable name as standard_name

### DIFF
--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -754,7 +754,12 @@ def calc_extracted_vars(source_dataset, output_coords, config, model_profile):
             std_name = var.attrs["standard_name"]
         except KeyError:
             # HRDPS lacks standard_name for many vars, but has short_name
-            std_name = var.attrs["short_name"]
+            try:
+                std_name = var.attrs["short_name"]
+            except KeyError:
+                # Fall back to variable name as standard_name as implied by
+                # https://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#long-name
+                std_name = name
         extracted_var = create_dataarray(
             name,
             var.isel(var_selector),


### PR DESCRIPTION
Change to allow the extraction function to use the variable name as a fallback option for the standard_name attribute when both the standard_name and short_name attributes are missing from the source dataset. This aligns with the CF conventions; see
http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#long-name