### PR TITLE
Move `xarray.open_mfdataset()` `parallel` parameter value to extraction config YAML file

### DIFF
--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -458,6 +458,7 @@ def open_dataset(ds_paths, chunk_size, config):
         with xarray.open_dataset(ds_path, chunks=chunk_size) as ds:
             drop_vars.update(var for var in ds.data_vars)
     drop_vars -= extract_vars
+    parallel_read = config.get("parallel read", False)
     ds = xarray.open_mfdataset(
         ds_paths,
         chunks=chunk_size,
@@ -465,7 +466,7 @@ def open_dataset(ds_paths, chunk_size, config):
         coords="minimal",
         data_vars="minimal",
         drop_variables=drop_vars,
-        parallel=True,
+        parallel=parallel_read,
     )
     if not ds.data_vars:
         logger.error(

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -661,6 +661,31 @@ class TestOpenDataset:
 
         xarray.testing.assert_equal(ds, source_dataset)
 
+    def test_open_dataset_parallel_read(self, source_dataset, log_output, tmp_path):
+        results_archive = tmp_path / "results_archive"
+        results_archive.mkdir()
+        source_dataset.to_netcdf(results_archive / "test_dataset.nc")
+        ds_paths = [results_archive / "test_dataset.nc"]
+        chunk_size = {
+            "time_counter": 4,
+            "deptht": 8,
+            "y": 9,
+            "x": 4,
+        }
+        extract_config = {
+            "parallel read": True,
+            "extract variables": [
+                "diatoms",
+            ],
+        }
+        ds = extract.open_dataset(ds_paths, chunk_size, extract_config)
+
+        assert log_output.entries[0]["log_level"] == "debug"
+        assert log_output.entries[0]["event"] == "opened dataset"
+        assert log_output.entries[0]["ds"] == ds
+
+        xarray.testing.assert_equal(ds, source_dataset)
+
     def test_exit_when_no_dataset_vars(self, source_dataset, log_output, tmp_path):
         """re: issue #37
 


### PR DESCRIPTION
Move setting of the `parallel` parameter for `xarray.open_mfdataset ()` to the extraction configuration YAML file, with its default value set to `False`.

Parallel reading on salish has become unreliable, often resulting in one of several errors from the backend netCDf4 or HDF5 libraries. Research into the errors suggests that the issue is due to some combination of file system performance, and interaction of thread/process management between `dask.delayed` and the backend libraries (e.g. https://github.com/ecmwf/cfgrib/issues/110),