### PR TITLE
Update Sphinx & sphinx-rtd-theme versions

### DIFF
--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -43,9 +43,9 @@ dependencies:
   - tomli
 
   # For documentation
-  - sphinx=5.3.0
+  - sphinx=7.2.6
   - sphinx-notfound-page=1.0.0
-  - sphinx-rtd-theme=1.3.0
+  - sphinx-rtd-theme=2.0.0
 
   - pip:
     # install of Reshapr package in editable mode

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -11,9 +11,9 @@ dependencies:
   - python=3.12
 
   # Sphinx and extensions
-  - sphinx=5.3.0
+  - sphinx=7.2.6
   - sphinx-notfound-page=1.0.0
-  - sphinx-rtd-theme=1.3.0
+  - sphinx-rtd-theme=2.0.0
 
   # readthedocs build system packages
   - mock

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -32,9 +32,9 @@ dependencies:
   - tomli
 
   # For documentation links checking
-  - sphinx=5.3.0
+  - sphinx=7.2.6
   - sphinx-notfound-page=1.0.0
-  - sphinx-rtd-theme=1.3.0
+  - sphinx-rtd-theme=2.0.0
 
   - pip:
     # install Reshapr package in editable mode


### PR DESCRIPTION
We upgraded to Sphinx v7.2.6 and sphinx-rtd-theme v2.0.0 to include the latest features of these packages and maintain up-to-date environments.