### PR TITLE
Update ubcSSnBathymetryV21-08 bathymetry dataset refs

### DIFF
--- a/docs/examples/iona_wastewater_discharge_analysis.rst
+++ b/docs/examples/iona_wastewater_discharge_analysis.rst
@@ -327,11 +327,9 @@ Here is the contents of the :file:`SalishSeaCast-202111-wastewater-salish.yaml` 
       x: 398
 
     geo ref dataset:
-      path: /results2/SalishSea/nowcast-green.202111/01jan07/SalishSea_1h_20070101_20070101_grid_T.nc
-      y coord: y
-      x coord: x
-      longitude var: nav_lon
-      latitude var: nav_lat
+      path: https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV21-08
+      y coord: gridY
+      x coord: gridX
 
     extraction time origin: 2007-01-01
 

--- a/model_profiles/SalishSeaCast-202111-month-avg-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-month-avg-salish.yaml
@@ -20,14 +20,9 @@ chunk size:
   x: 398
 
 geo ref dataset:
-  # TODO: update to ERDDAP URL when bathymetry dataset is published there
-  path: /results2/SalishSea/nowcast-green.202111/01jan07/SalishSea_1h_20070101_20070101_grid_T.nc
-  # TODO: Update coordinate names when bathymetry dataset is published on ERDDAP
-  y coord: y
-  x coord: x
-  # TODO: Drop unnecessary lon/lat var names when bathymetry dataset is published on ERDDAP
-  longitude var: nav_lon
-  latitude var: nav_lat
+  path: https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV21-08
+  y coord: gridY
+  x coord: gridX
 
 extraction time origin: 2007-01-01
 

--- a/model_profiles/SalishSeaCast-202111-salish.yaml
+++ b/model_profiles/SalishSeaCast-202111-salish.yaml
@@ -19,14 +19,9 @@ chunk size:
   x: 398
 
 geo ref dataset:
-  # TODO: update to ERDDAP URL when bathymetry dataset is published there
-  path: /results2/SalishSea/nowcast-green.202111/01jan07/SalishSea_1h_20070101_20070101_grid_T.nc
-  # TODO: Update coordinate names when bathymetry dataset is published on ERDDAP
-  y coord: y
-  x coord: x
-  # TODO: Drop unnecessary lon/lat var names when bathymetry dataset is published on ERDDAP
-  longitude var: nav_lon
-  latitude var: nav_lat
+  path: https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV21-08
+  y coord: gridY
+  x coord: gridX
 
 extraction time origin: 2007-01-01
 

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -488,17 +488,12 @@ class TestSalishSeaCast202111:
             "x": 398,
         }
         assert model_profile["chunk size"] == expected_chunk_size
-        # TODO: update to ERDDAP URL when bathymetry dataset is published there
         assert (
             model_profile["geo ref dataset"]["path"]
-            == "/results2/SalishSea/nowcast-green.202111/01jan07/SalishSea_1h_20070101_20070101_grid_T.nc"
+            == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV21-08"
         )
-        # TODO: Update coordinate names when bathymetry dataset is published on ERDDAP
-        assert model_profile["geo ref dataset"]["y coord"] == "y"
-        assert model_profile["geo ref dataset"]["x coord"] == "x"
-        # TODO: Drop unnecessary lon/lat var names when bathymetry dataset is published on ERDDAP
-        assert model_profile["geo ref dataset"]["longitude var"] == "nav_lon"
-        assert model_profile["geo ref dataset"]["latitude var"] == "nav_lat"
+        assert model_profile["geo ref dataset"]["y coord"] == "gridY"
+        assert model_profile["geo ref dataset"]["x coord"] == "gridX"
         assert model_profile["extraction time origin"] == arrow.get("2007-01-01").date()
         assert (
             model_profile["results archive"]["path"]
@@ -649,17 +644,12 @@ class TestSalishSeaCast202111MonthAvg:
             "x": 398,
         }
         assert model_profile["chunk size"] == expected_chunk_size
-        # TODO: update to ERDDAP URL when bathymetry dataset is published there
         assert (
             model_profile["geo ref dataset"]["path"]
-            == "/results2/SalishSea/nowcast-green.202111/01jan07/SalishSea_1h_20070101_20070101_grid_T.nc"
+            == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV21-08"
         )
-        # TODO: Update coordinate names when bathymetry dataset is published on ERDDAP
-        assert model_profile["geo ref dataset"]["y coord"] == "y"
-        assert model_profile["geo ref dataset"]["x coord"] == "x"
-        # TODO: Drop unnecessary lon/lat var names when bathymetry dataset is published on ERDDAP
-        assert model_profile["geo ref dataset"]["longitude var"] == "nav_lon"
-        assert model_profile["geo ref dataset"]["latitude var"] == "nav_lat"
+        assert model_profile["geo ref dataset"]["y coord"] == "gridY"
+        assert model_profile["geo ref dataset"]["x coord"] == "gridX"
         assert model_profile["extraction time origin"] == arrow.get("2007-01-01").date()
         assert (
             model_profile["results archive"]["path"]


### PR DESCRIPTION
Update the references to the new ubcSSnBathymetryV21-08 ERDDAP bathymetry dataset across the model profiles and test cases. The bathymetry dataset has been published on ERDDAP, therefore locations and var names were updated to reflect this change, getting rid of previous local file paths and unnecessary lon/lat variable names.