### PR TITLE
Add month start/end date patterns to `info` variabless list generation

### DIFF
--- a/reshapr/core/info.py
+++ b/reshapr/core/info.py
@@ -219,6 +219,8 @@ def _vars_list(model_profile, time_interval, vars_group, console):
     nc_files_pattern = dataset["file pattern"].format(
         ddmmmyy="*",
         yyyymmdd="*",
+        yyyymm01="*",
+        yyyymm_end="*",
         yyyy="*",
         nemo_yyyymm="*",
         nemo_yyyymmdd="*",


### PR DESCRIPTION
Add month start/end date patterns 'yyyymm01' and 'yyyymm_end' to `info._vars_list()`. This was missed in PR#109.