### PR TITLE
Update hatch wheel build target inclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ show_missing = true
 
 
 [tool.hatch.build.targets.wheel]
-packages = ["reshapr"]
+include = [
+    "reshapr",
+    "cluster_configs",
+    "model_profiles",
+]
 
 [tool.hatch.version]
 path = "reshapr/__about__.py"


### PR DESCRIPTION
Add cluster_configs/ and model_profiles/ directories to the built wheel because they are essential to using Reshapr.

The need to do this seems to have arisen from the change in package identification heuristics in Hatchling 1.19.0. But it is also possible that we just didn't notice arlier because we generally install Reshapr in editable mode.