### PR TITLE
Restore `netcdf4` to `pyproject.toml` dependencies list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "dask",
     "flox",
     "h5netcdf",
+    "netcdf4",
     "pyyaml",
     "rich",
     "structlog",


### PR DESCRIPTION
This change restores the `netcdf4` package to the list of dependencies in the `pyproject.toml` file. This corrects and error introduced in PR #132 when `netcdf4` was replaced with `h5netcdf`. Subsequent testing in that PR revealed that we presently can only use `h5netcdf` for dataset reading and must continue to use `netcdf4` for dataset writing. So, both packages are dependencies.