### PR TITLE
Update threads per worker to 1 in configs and docs

### DIFF
--- a/cluster_configs/salish_cluster.yaml
+++ b/cluster_configs/salish_cluster.yaml
@@ -3,5 +3,5 @@
 name: salish dask cluster
 processes: True
 number of workers: 4
-threads per worker: 4
+threads per worker: 1
 memory limit: auto

--- a/docs/dask_clusters.rst
+++ b/docs/dask_clusters.rst
@@ -99,7 +99,7 @@ a ``bash`` loop to resample day-averaged datasets to get month-averaged datasets
    .. code-block:: bash
 
        $ conda activate reshapr
-       (reshapr)$ dask-worker --nworkers=1 --nthreads=4 142.103.36.12:8786 &
+       (reshapr)$ dask-worker --nworkers=1 --nthreads=1 142.103.36.12:8786 &
 
    Use :kbd:`Control-b ,` to rename the ``tmux`` terminal to ``dask-workers``.
 

--- a/docs/subcommands/info.rst
+++ b/docs/subcommands/info.rst
@@ -90,7 +90,7 @@ Example:
       name: salish dask cluster
       processes: True
       number of workers: 4
-      threads per worker: 4
+      threads per worker: 1
 
     Please use reshapr info --help to learn how to get other information,
     or reshapr --help to learn about other sub-commands.

--- a/tests/core/test_info.py
+++ b/tests/core/test_info.py
@@ -123,7 +123,7 @@ class TestClusterInfo:
                 name: salish dask cluster
                 processes: True
                 number of workers: 4
-                threads per worker: 4
+                threads per worker: 1
             """
         ).splitlines()
         assert [line.strip() for line in stdout_lines[1:7]] == expected

--- a/tests/test_cluster_configs.py
+++ b/tests/test_cluster_configs.py
@@ -57,7 +57,7 @@ class TestSalishCluster:
         assert cluster_config["name"] == "salish dask cluster"
         assert cluster_config["processes"] is True
         assert cluster_config["number of workers"] == 4
-        assert cluster_config["threads per worker"] == 4
+        assert cluster_config["threads per worker"] == 1
         assert cluster_config["memory limit"] == "auto"
 
 


### PR DESCRIPTION
This is done to increase the reliability of Reshapr extractions. With threads>1 we see random occurrences of errors like:
  `RuntimeError: NetCDF: Not a valid ID`
The root cause appears to be that the `netcdf-c` is not thread-safe and a change introduced in `netcdf4-python=1.6.1` removed a work-around for the lack of thread-safety.

See discussion in https://github.com/xCDAT/xcdat/issues/561 and in other discussions linked there.