### PR TITLE
Fix broken and redirected documentation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Reshapr
 |                            |     :target: https://github.com/UBC-MOAD/Reshapr/actions?query=workflow:CodeQL                                                                                                             |
 |                            |     :alt: CodeQL analysis                                                                                                                                                                  |
 +----------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Documentation**          | .. image:: https://readthedocs.org/projects/reshapr/badge/?version=latest                                                                                                                  |
+| **Documentation**          | .. image:: https://app.readthedocs.org/projects/reshapr/badge/?version=latest                                                                                                              |
 |                            |     :target: https://reshapr.readthedocs.io/en/latest/                                                                                                                                     |
 |                            |     :alt: Documentation Status                                                                                                                                                             |
 |                            | .. image:: https://github.com/UBC-MOAD/Reshapr/actions/workflows/sphinx-linkcheck.yaml/badge.svg                                                                                           |

--- a/docs/design_notes/motivation.rst
+++ b/docs/design_notes/motivation.rst
@@ -57,8 +57,8 @@ that maps especially well to handling NetCDF-4 model results.
 Dask provides a flexible parallel computing framework for operating on extremely large
 datasets without loading them into memory.
 
-.. _converged on: https://www.pangeo.io/#ecosystem
-.. _Pangeo: https://www.pangeo.io/
+.. _converged on: https://pangeo.io/#ecosystem
+.. _Pangeo: https://pangeo.io/
 .. _Xarray: https://docs.xarray.dev/en/stable/
 .. _Dask: https://docs.dask.org/en/latest/
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -32,7 +32,7 @@
 |                            |     :target: https://github.com/UBC-MOAD/Reshapr/actions?query=workflow:CodeQL                                                                                                             |
 |                            |     :alt: CodeQL analysis                                                                                                                                                                  |
 +----------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Documentation**          | .. image:: https://readthedocs.org/projects/reshapr/badge/?version=latest                                                                                                                  |
+| **Documentation**          | .. image:: https://app.readthedocs.org/projects/reshapr/badge/?version=latest                                                                                                              |
 |                            |     :target: https://reshapr.readthedocs.io/en/latest/                                                                                                                                     |
 |                            |     :alt: Documentation Status                                                                                                                                                             |
 |                            | .. image:: https://github.com/UBC-MOAD/Reshapr/actions/workflows/sphinx-linkcheck.yaml/badge.svg                                                                                           |
@@ -202,7 +202,7 @@ and run :command:`pre-commit install`:
 Building the Documentation
 ==========================
 
-.. image:: https://readthedocs.org/projects/reshapr/badge/?version=latest
+.. image:: https://app.readthedocs.org/projects/reshapr/badge/?version=latest
     :target: https://reshapr.readthedocs.io/en/latest/
     :alt: Documentation Status
 
@@ -388,7 +388,7 @@ The output looks something like:
         (    installation: line   39) ok        https://ubc-moad-docs.readthedocs.io/en/latest/ssh_access.html#copyyourpublicsshkeytogithub
         (    installation: line   39) ok        https://ubc-moad-docs.readthedocs.io/en/latest/ssh_access.html#secureremoteaccess
         (           index: line   46) ok        https://www.apache.org/licenses/LICENSE-2.0
-        ( pkg_development: line   35) ok        https://readthedocs.org/projects/reshapr/badge/?version=latest
+        ( pkg_development: line   35) ok        https://app.readthedocs.org/projects/reshapr/badge/?version=latest
         (design_notes/motivation: line   53) ok        https://www.pangeo.io/
         (design_notes/motivation: line   53) ok        https://www.pangeo.io/#ecosystem
         ( pkg_development: line  209) ok        https://www.sphinx-doc.org/en/master/


### PR DESCRIPTION
Updated links in `motivation.rst`, `README.rst`, and `pkg_development.rst` to replace outdated or redirected URLs. This ensures up-to-date references to external resources and improves the documentation's reliability.