### PR TITLE
Pin pandas to <3.0.0 

### DIFF
--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -25,6 +25,7 @@ dependencies:
   - flox
   - h5netcdf
   - netCDF4
+  - pandas<3.0.0
   - pip
   - python=3.14
   - pyyaml

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -19,6 +19,7 @@ dependencies:
   - flox
   - h5netcdf
   - netCDF4
+  - pandas<3.0.0
   - pip
   - python
   - pyyaml

--- a/envs/environment-user.yaml
+++ b/envs/environment-user.yaml
@@ -19,6 +19,7 @@ dependencies:
   - flox
   - h5netcdf
   - netCDF4
+  - pandas<3.0.0
   - pip
   - python=3.14
   - pyyaml


### PR DESCRIPTION
* Added a version constraint for pandas in `environment-test.yaml` to test environments with pinned version in GHA workflows. The pin is meant to prevent issues with breaking changes in pandas 3.0.0.

re: issue #179 