### PR TITLE
fix: handle missing dataset files without traceback (#110)

### DIFF
--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -480,19 +480,27 @@ def open_dataset(ds_paths, chunk_size, config):
     # in the dataset, and from that the set of variables to drop.
     # We need to use the variables lists from 1st and last datasets to avoid issue #51.
     for ds_path in (ds_paths[0], ds_paths[-1]):
-        with xarray.open_dataset(ds_path, chunks=chunk_size, engine="h5netcdf") as ds:
-            drop_vars.update(var for var in ds.data_vars)
+        try:
+            with xarray.open_dataset(ds_path, chunks=chunk_size, engine="h5netcdf") as ds:
+                drop_vars.update(var for var in ds.data_vars)
+        except FileNotFoundError:
+            logger.error("dataset file not found", dataset_path=os.fspath(ds_path))
+            raise SystemExit(2)
     drop_vars -= extract_vars
     parallel_read = config.get("parallel read", True)
-    ds = xarray.open_mfdataset(
-        ds_paths,
-        chunks=chunk_size,
-        compat="override",
-        coords="minimal",
-        data_vars="minimal",
-        drop_variables=drop_vars,
-        parallel=parallel_read,
-    )
+    try:
+        ds = xarray.open_mfdataset(
+            ds_paths,
+            chunks=chunk_size,
+            compat="override",
+            coords="minimal",
+            data_vars="minimal",
+            drop_variables=drop_vars,
+            parallel=parallel_read,
+        )
+    except FileNotFoundError as exc:
+        logger.error("dataset file not found", error=str(exc))
+        raise SystemExit(2)
     if not ds.data_vars:
         logger.error(
             "no variables in source dataset",

--- a/reshapr/core/extract.py
+++ b/reshapr/core/extract.py
@@ -481,7 +481,9 @@ def open_dataset(ds_paths, chunk_size, config):
     # We need to use the variables lists from 1st and last datasets to avoid issue #51.
     for ds_path in (ds_paths[0], ds_paths[-1]):
         try:
-            with xarray.open_dataset(ds_path, chunks=chunk_size, engine="h5netcdf") as ds:
+            with xarray.open_dataset(
+                ds_path, chunks=chunk_size, engine="h5netcdf"
+            ) as ds:
                 drop_vars.update(var for var in ds.data_vars)
         except FileNotFoundError:
             logger.error("dataset file not found", dataset_path=os.fspath(ds_path))

--- a/tests/core/test_extract.py
+++ b/tests/core/test_extract.py
@@ -348,6 +348,23 @@ class TestCliExtract:
         assert (tmp_path / "SalishSeaCast_1d_diatoms_20150401_20150401.nc").exists()
 
 
+class TestOpenDatasetMissingFiles:
+    """Unit tests for missing dataset file handling in open_dataset()."""
+
+    def test_missing_first_dataset_path_exits_cleanly(self, log_output, tmp_path):
+        ds_paths = [tmp_path / "missing-first.nc"]
+        chunk_size = {"time_counter": 1}
+        config = {"extract variables": ["diatoms"]}
+
+        with pytest.raises(SystemExit) as exc_info:
+            extract.open_dataset(ds_paths, chunk_size, config)
+
+        assert exc_info.value.code == 2
+        assert log_output.entries[0]["log_level"] == "error"
+        assert log_output.entries[0]["dataset_path"] == os.fspath(ds_paths[0])
+        assert log_output.entries[0]["event"] == "dataset file not found"
+
+
 class TestLoadConfig:
     """Unit tests for core.extract._load_config() function."""
 


### PR DESCRIPTION
## Summary

Closes #110

This change converts missing dataset files during extraction into a clean CLI error instead of allowing the `FileNotFoundError` from xarray/h5netcdf to surface as a traceback.

It handles both places mentioned in the issue:

- the first/last dataset probes used to build the `drop_vars` set
- the later `xarray.open_mfdataset()` call over the full dataset path list

## Test plan

- `pytest -q tests/core/test_extract.py::TestOpenDatasetMissingFiles::test_missing_first_dataset_path_exits_cleanly`
- `pytest -q tests/core/test_extract.py::TestOpenDatasetMissingFiles tests/core/test_extract.py::TestCliExtract::test_no_config_file tests/core/test_extract.py::TestCliExtract::test_cli_extract`
- `python -m compileall -q reshapr/core/extract.py tests/core/test_extract.py`
