### PR TITLE
Update memory limit for Salish cluster test

### DIFF
--- a/docs/subcommands/info.rst
+++ b/docs/subcommands/info.rst
@@ -101,7 +101,7 @@ Example:
       processes: True
       number of workers: 4
       threads per worker: 1
-      memory limit: auto
+      memory limit: "64G"
 
     Please use reshapr info --help to learn how to get other information,
     or reshapr --help to learn about other sub-commands.

--- a/tests/test_cluster_configs.py
+++ b/tests/test_cluster_configs.py
@@ -62,7 +62,7 @@ class TestSalishCluster:
         assert cluster_config["processes"] is True
         assert cluster_config["number of workers"] == 4
         assert cluster_config["threads per worker"] == 1
-        assert cluster_config["memory limit"] == "auto"
+        assert cluster_config["memory limit"] == "64G"
 
 
 class TestUnitTestCluster:


### PR DESCRIPTION
Changed the expected memory limit in `test_cluster_configs` from "auto" to "64G" because "auto" results in too little memory per worker. This ensures test alignment with the change that Susan made in b55ef750d44.